### PR TITLE
fix: add lint rule to prevent extaneous imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,4 +6,8 @@ const config = require('./packages/eslint-config/index');
 module.exports = {
   root: true,
   ...config,
+  rules: {
+    ...config.rules,
+    'import/no-extraneous-dependencies': 'off', // not every package explicitly lists their dev deps
+  },
 };

--- a/.huskyrc
+++ b/.huskyrc
@@ -2,6 +2,7 @@
   "hooks": {
     "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
     "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true",
-    "pre-commit": "yarn lint-staged"
+    "pre-commit": "yarn lint-staged",
+    "pre-push": "yarn test:changes"
   }
 }

--- a/@types/styled-components.d.ts
+++ b/@types/styled-components.d.ts
@@ -1,5 +1,4 @@
 import 'styled-components';
-import { CssFunctionReturnType } from '@styled-system/css';
 import { ThemeObject } from '../packages/zephyr';
 
 declare module 'styled-components' {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "yarn bootstrap",
     "storybook": "start-storybook -p 6006",
     "test": "tsdx test",
-    "test:changes": "tsdx test --changedSince master",
+    "test:changes": "tsdx test --changedSince=main",
     "test:ci": "yarn test --ci --coverage --maxWorkers=2",
     "test:watch": "tsdx test --watch"
   },

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -129,6 +129,7 @@ const config = {
         groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
       },
     ],
+    'import/no-extraneous-dependencies': 'error',
     'import/no-default-export': 'error',
     'import/default': 'off', // doesn't seem to work
     'import/no-unresolved': 'error',


### PR DESCRIPTION
So this happened https://github.com/AirLabsTeam/next/pull/185 (private repo, sorry open source world)... and [this rule](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md) will prevent that.