### PR TITLE
Fix type issue with "as" prop on <Text>

### DIFF
--- a/packages/zephyr/src/Text.tsx
+++ b/packages/zephyr/src/Text.tsx
@@ -1,13 +1,15 @@
-import React, { forwardRef } from 'react';
-
-import { Box, BoxProps } from './Box';
+import React from 'react';
+import { forwardRefWithAs, PropsWithAs } from '@reach/utils';
+import { Box } from './Box';
 import { TextVariantName } from './theme/variants/text';
 
-export interface TextProps extends Omit<BoxProps, '__baseStyles' | 'variant'> {
+export type NonSemanticTextProps = {
   variant?: TextVariantName | TextVariantName[];
-}
+};
 
-export const Text = forwardRef<any, TextProps>(
+export interface TextProps extends PropsWithAs<'div', NonSemanticTextProps> {}
+
+export const Text = forwardRefWithAs<NonSemanticTextProps, 'div'>(
   ({ variant = 'text-ui-16', ...restOfProps }: TextProps, ref) => {
     return (
       <Box variant={variant} ref={ref} {...restOfProps} __baseStyles={{ color: 'pigeon700' }} />

--- a/packages/zephyr/stories/Text.stories.tsx
+++ b/packages/zephyr/stories/Text.stories.tsx
@@ -116,3 +116,10 @@ UI.parameters = {
     },
   },
 };
+
+export const TextAs: Story<TextProps> = (args) => (
+  <Text {...args} as="span" variant="text-ui-16">
+    This story acts as an integration test asserting that we can render the item as another semantic
+    element.
+  </Text>
+);


### PR DESCRIPTION
The current implementation only allows the "as" prop to be `undefined` or `'div'` yielding a few type errors throughout the app. Additionally, the v4 didnt have duck-typing working when "as" was defined. This will resolve that issue.