### PR TITLE
Remove "ref" from the prop typings for both Button and Text

### DIFF
--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -14,7 +14,7 @@ export type NonSemanticButtonProps = Pick<BoxStylingProps, 'tx'> & {
   variant?: ButtonVariantName;
 };
 
-export interface ButtonProps extends PropsWithAs<'button', NonSemanticButtonProps> {}
+export interface ButtonProps extends Omit<PropsWithAs<'button', NonSemanticButtonProps>, 'ref'> {}
 
 const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
   (

--- a/packages/zephyr/src/Text.tsx
+++ b/packages/zephyr/src/Text.tsx
@@ -7,7 +7,7 @@ export type NonSemanticTextProps = Pick<BoxStylingProps, 'tx'> & {
   variant?: TextVariantName | TextVariantName[];
 };
 
-export interface TextProps extends PropsWithAs<'div', NonSemanticTextProps> {}
+export interface TextProps extends Omit<PropsWithAs<'div', NonSemanticTextProps>, 'ref'> {}
 
 export const Text = forwardRefWithAs<NonSemanticTextProps, 'div'>(
   ({ variant = 'text-ui-16', ...restOfProps }: TextProps, ref) => {


### PR DESCRIPTION
It was incorrect to suggest that "ref" was a valid prop. It's valid to pass as a prop to the actual
component, but ref is technically never a valid prop for a function component

BREAKING CHANGE: Remove "ref" from ButtonProps and TextProps