### PR TITLE
Fix: disable hover styling on disabled buttons

### DIFF
--- a/packages/zephyr/src/theme/variants/button.ts
+++ b/packages/zephyr/src/theme/variants/button.ts
@@ -58,7 +58,7 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
   },
   'button-ghost-blue': {
     color: 'jay500',
-    '&:hover': {
+    '&:hover:not(:disabled)': {
       backgroundColor: 'jay050',
       color: 'jay700',
     },
@@ -104,7 +104,7 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
     border: '1px solid',
     borderColor: 'jay200',
     color: 'jay500',
-    '&:hover': {
+    '&:hover:not(:disabled)': {
       backgroundColor: 'jay100',
       borderColor: 'transparent',
       color: 'jay600',


### PR DESCRIPTION
Some variants still showed hover styling while disabled, fixed in variants style object