### PR TITLE
Button `isLoading` prop

### DIFF
--- a/packages/zephyr/package.json
+++ b/packages/zephyr/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@air/icons": "^4.0.0",
     "@styled-system/css": "^5.1.5",
+    "@types/classnames": "^2.2.11",
     "@types/styled-system": "^5.1.10",
     "@types/styled-system__css": "^5.0.14",
     "@types/yup": "^0.29.9",
@@ -60,6 +61,7 @@
     "@reach/alert-dialog": "^0.11.2",
     "@reach/auto-id": "^0.11.2",
     "@reach/dialog": "^0.11.2",
-    "@reach/visually-hidden": "^0.11.1"
+    "@reach/visually-hidden": "^0.11.1",
+    "classnames": "^2.2.6"
   }
 }

--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { transitions } from 'polished';
 import { forwardRefWithAs, PropsWithAs } from '@reach/utils';
 import { variant as styledSystemVariant } from 'styled-system';
-import { useTheme } from 'styled-components';
+import invariant from 'tiny-invariant';
+import { useReducedMotion } from 'framer-motion';
+import VisuallyHidden from '@reach/visually-hidden';
+import styled, { keyframes, useTheme } from 'styled-components';
 import { Box, BoxStylingProps } from './Box';
 import { ButtonVariantName } from './theme/variants/button';
 
@@ -14,9 +17,62 @@ export type ButtonSize = 'large' | 'medium' | 'small';
 export type NonSemanticButtonProps = Pick<BoxStylingProps, 'tx'> & {
   size?: ButtonSize;
   variant?: ButtonVariantName;
+  /**
+   * `isLoading` can only be true for buttons with filled variants.
+   */
+  isLoading?: boolean;
 };
 
 export interface ButtonProps extends PropsWithAs<'button', NonSemanticButtonProps> {}
+
+const Dot = () => (
+  <Box
+    tx={{
+      display: 'inline-block',
+      backgroundColor: 'currentColor',
+      borderRadius: 999,
+      height: 4,
+      width: 4,
+    }}
+  />
+);
+
+const wave = keyframes`
+  0% { transform: translate(0, -1.5px); }
+  50% { transform: translate(0, 1.5px); }
+  100% { transform: translate(0,-1.5px); }
+`;
+
+const Loader = styled(Box)<{ shouldReduceMotion: boolean }>`
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+
+  div {
+    animation-name: ${({ shouldReduceMotion }) => (shouldReduceMotion ? 'none' : wave)};
+    animation-duration: 0.98s;
+    animation-timing-function: ease-in-out;
+    animation-delay: 0s;
+    animation-fill-mode: both;
+    animation-iteration-count: infinite;
+  }
+
+  div:nth-child(1) {
+    animation-delay: 0s;
+    margin-right: 4px;
+  }
+
+  div:nth-child(2) {
+    animation-delay: 0.14s;
+    margin-right: 4px;
+  }
+
+  div:nth-child(3) {
+    animation-delay: 0.28s;
+  }
+`;
 
 export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
   (
@@ -26,19 +82,33 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
       size = 'medium',
       type = 'button',
       variant = 'button-filled-blue',
+      isLoading = false,
       ref: _ref, // eslint-disable-line @typescript-eslint/no-unused-vars
+      children,
+      className = '',
       ...restOfProps
     }: ButtonProps,
     ref: React.Ref<HTMLButtonElement>,
   ) => {
+    invariant(
+      (isLoading &&
+        (variant === 'button-filled-blue' ||
+          variant === 'button-filled-grey' ||
+          variant === 'button-filled-destructive')) ||
+        !isLoading,
+      'Button can only have loading state if it is a filled variant',
+    );
+
     const theme = useTheme();
+    const shouldReduceMotion = useReducedMotion();
 
     return (
       <Box
         as={as}
-        disabled={disabled}
+        disabled={disabled || isLoading}
         type={type}
         variant={variant}
+        className={isLoading ? `${className} isLoading` : `${className}`}
         __baseStyles={{
           appearance: 'none',
           outline: 'none',
@@ -87,7 +157,28 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
         }}
         {...restOfProps}
         ref={ref}
-      />
+      >
+        <Box role="status" tx={{ position: 'relative' }}>
+          {isLoading && (
+            <>
+              <VisuallyHidden>Loading...</VisuallyHidden>
+              <Loader aria-hidden="true" shouldReduceMotion={shouldReduceMotion!}>
+                <Dot />
+                <Dot />
+                <Dot />
+              </Loader>
+            </>
+          )}
+          <Box
+            tx={{
+              opacity: isLoading ? 0 : 1,
+              visibility: isLoading ? 'hidden' : 'visible',
+            }}
+          >
+            {children}
+          </Box>
+        </Box>
+      </Box>
     );
   },
 );

--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -5,6 +5,7 @@ import { variant as styledSystemVariant } from 'styled-system';
 import invariant from 'tiny-invariant';
 import { useReducedMotion } from 'framer-motion';
 import VisuallyHidden from '@reach/visually-hidden';
+import classNames from 'classnames';
 import styled, { keyframes, useTheme } from 'styled-components';
 import { Box, BoxStylingProps } from './Box';
 import { ButtonVariantName } from './theme/variants/button';
@@ -40,7 +41,7 @@ const Dot = () => (
 const wave = keyframes`
   0% { transform: translate(0, -1.5px); }
   50% { transform: translate(0, 1.5px); }
-  100% { transform: translate(0,-1.5px); }
+  100% { transform: translate(0, -1.5px); }
 `;
 
 const Loader = styled(Box)<{ shouldReduceMotion: boolean }>`
@@ -61,12 +62,11 @@ const Loader = styled(Box)<{ shouldReduceMotion: boolean }>`
 
   div:nth-child(1) {
     animation-delay: 0s;
-    margin-right: 4px;
   }
 
   div:nth-child(2) {
     animation-delay: 0.14s;
-    margin-right: 4px;
+    margin: 0 4px;
   }
 
   div:nth-child(3) {
@@ -85,7 +85,7 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
       isLoading = false,
       ref: _ref, // eslint-disable-line @typescript-eslint/no-unused-vars
       children,
-      className = '',
+      className,
       ...restOfProps
     }: ButtonProps,
     ref: React.Ref<HTMLButtonElement>,
@@ -108,7 +108,8 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
         disabled={disabled || isLoading}
         type={type}
         variant={variant}
-        className={isLoading ? `${className} isLoading` : `${className}`}
+        // className={isLoading ? `${className} isLoading` : `${className}`}
+        className={classNames({ 'is-loading': isLoading }, className)}
         __baseStyles={{
           appearance: 'none',
           outline: 'none',
@@ -153,6 +154,9 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
           },
           '&:disabled': {
             cursor: 'not-allowed',
+          },
+          '&.isLoading': {
+            cursor: 'wait',
           },
         }}
         {...restOfProps}

--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -19,7 +19,7 @@ export type NonSemanticButtonProps = Pick<BoxStylingProps, 'tx'> & {
   size?: ButtonSize;
   variant?: ButtonVariantName;
   /**
-   * `isLoading` can only be true for buttons with filled variants.
+   * `isLoading` can only be true for buttons with boundaries (ie. filled and outline variants). Note: `button-outline-destructive` is not currently a variant.
    */
   isLoading?: boolean;
 };

--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -98,7 +98,7 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
           variant === 'button-outline-blue' ||
           variant === 'button-outline-grey')) ||
         !isLoading,
-      'Button can only have loading state if it is a filled or outlined variant, please discuss deviations with Design.',
+      "Button can only have loading state if it is a filled or outlined variant. Currently, there is no 'button-outline-destructive' variant. Please discuss deviations with Design.",
     );
 
     const theme = useTheme();

--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -154,8 +154,8 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
           '&:disabled': {
             cursor: 'not-allowed',
           },
-          '&.isLoading': {
-            cursor: 'wait',
+          '&.is-loading': {
+            cursor: 'progress',
           },
         }}
         {...restOfProps}

--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -108,7 +108,6 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
         disabled={disabled || isLoading}
         type={type}
         variant={variant}
-        // className={isLoading ? `${className} isLoading` : `${className}`}
         className={classNames({ 'is-loading': isLoading }, className)}
         __baseStyles={{
           appearance: 'none',

--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -94,9 +94,11 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
       (isLoading &&
         (variant === 'button-filled-blue' ||
           variant === 'button-filled-grey' ||
-          variant === 'button-filled-destructive')) ||
+          variant === 'button-filled-destructive' ||
+          variant === 'button-outline-blue' ||
+          variant === 'button-outline-grey')) ||
         !isLoading,
-      'Button can only have loading state if it is a filled variant',
+      'Button can only have loading state if it is a filled or outlined variant, please discuss deviations with Design.',
     );
 
     const theme = useTheme();

--- a/packages/zephyr/src/theme/variants/button.ts
+++ b/packages/zephyr/src/theme/variants/button.ts
@@ -11,17 +11,18 @@ export type ButtonVariantName =
   | 'button-outline-grey'
   | 'button-unstyled';
 
+// isLoading state should keep base styles on button-filled variants
 const _button: { [key in ButtonVariantName]: TXProp } = {
   'button-filled-blue': {
     backgroundColor: 'jay500',
     color: 'white',
-    '&:hover': {
+    '&:hover:not(.isLoading)': {
       backgroundColor: 'jay600',
     },
-    '&:active': {
+    '&:active:not(.isLoading)': {
       backgroundColor: 'jay700',
     },
-    '&:disabled': {
+    '&:disabled:not(.isLoading)': {
       backgroundColor: 'pigeon050',
       color: 'pigeon400',
     },
@@ -29,13 +30,13 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
   'button-filled-destructive': {
     backgroundColor: 'flamingo600',
     color: 'white',
-    '&:hover': {
+    '&:hover:not(.isLoading)': {
       backgroundColor: 'flamingo700',
     },
-    '&:active': {
+    '&:active:not(.isLoading)': {
       backgroundColor: 'flamingo800',
     },
-    '&:disabled': {
+    '&:disabled:not(.isLoading)': {
       backgroundColor: 'transparent',
       color: 'pigeon300',
     },
@@ -43,15 +44,15 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
   'button-filled-grey': {
     backgroundColor: 'pigeon050',
     color: 'pigeon600',
-    '&:hover': {
+    '&:hover:not(.isLoading)': {
       backgroundColor: 'pigeon100',
       color: 'pigeon700',
     },
-    '&:active': {
+    '&:active:not(.isLoading)': {
       backgroundColor: 'pigeon200',
       color: 'pigeon700',
     },
-    '&:disabled': {
+    '&:disabled:not(.isLoading)': {
       backgroundColor: 'transparent',
       color: 'pigeon300',
     },

--- a/packages/zephyr/src/theme/variants/button.ts
+++ b/packages/zephyr/src/theme/variants/button.ts
@@ -16,13 +16,13 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
   'button-filled-blue': {
     backgroundColor: 'jay500',
     color: 'white',
-    '&:hover:not(.isLoading)': {
+    '&:hover:not(.is-loading)': {
       backgroundColor: 'jay600',
     },
-    '&:active:not(.isLoading)': {
+    '&:active:not(.is-loading)': {
       backgroundColor: 'jay700',
     },
-    '&:disabled:not(.isLoading)': {
+    '&:disabled:not(.is-loading)': {
       backgroundColor: 'pigeon050',
       color: 'pigeon400',
     },
@@ -30,13 +30,13 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
   'button-filled-destructive': {
     backgroundColor: 'flamingo600',
     color: 'white',
-    '&:hover:not(.isLoading)': {
+    '&:hover:not(.is-loading)': {
       backgroundColor: 'flamingo700',
     },
-    '&:active:not(.isLoading)': {
+    '&:active:not(.is-loading)': {
       backgroundColor: 'flamingo800',
     },
-    '&:disabled:not(.isLoading)': {
+    '&:disabled:not(.is-loading)': {
       backgroundColor: 'transparent',
       color: 'pigeon300',
     },
@@ -44,15 +44,15 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
   'button-filled-grey': {
     backgroundColor: 'pigeon050',
     color: 'pigeon600',
-    '&:hover:not(.isLoading)': {
+    '&:hover:not(.is-loading)': {
       backgroundColor: 'pigeon100',
       color: 'pigeon700',
     },
-    '&:active:not(.isLoading)': {
+    '&:active:not(.is-loading)': {
       backgroundColor: 'pigeon200',
       color: 'pigeon700',
     },
-    '&:disabled:not(.isLoading)': {
+    '&:disabled:not(.is-loading)': {
       backgroundColor: 'transparent',
       color: 'pigeon300',
     },

--- a/packages/zephyr/src/theme/variants/button.ts
+++ b/packages/zephyr/src/theme/variants/button.ts
@@ -110,12 +110,12 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
       borderColor: 'transparent',
       color: 'jay600',
     },
-    '&:active': {
+    '&:active:not(.is-loading)': {
       backgroundColor: 'jay200',
       borderColor: 'transparent',
       color: 'jay700',
     },
-    '&:disabled': {
+    '&:disabled:not(.is-loading)': {
       color: 'pigeon300',
       borderColor: 'pigeon100',
     },
@@ -124,17 +124,17 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
     border: '1px solid',
     borderColor: 'pigeon200',
     color: 'pigeon600',
-    '&:hover': {
+    '&:hover:not(.is-loading)': {
       backgroundColor: 'pigeon050',
       borderColor: 'transparent',
       color: 'pigeon700',
     },
-    '&:active': {
+    '&:active:not(.is-loading)': {
       backgroundColor: 'pigeon100',
       borderColor: 'transparent',
       color: 'pigeon700',
     },
-    '&:disabled': {
+    '&:disabled:not(.is-loading)': {
       backgroundColor: 'transparent',
       color: 'pigeon300',
       borderColor: 'pigeon100',

--- a/packages/zephyr/stories/buttons/FilledButton.stories.tsx
+++ b/packages/zephyr/stories/buttons/FilledButton.stories.tsx
@@ -36,6 +36,11 @@ export const FilledBlueButton = () => (
     <Button size="medium" disabled variant="button-filled-blue">
       Disabled blue button
     </Button>
+    <br />
+    <br />
+    <Button size="medium" isLoading variant="button-filled-blue">
+      Blue button
+    </Button>
   </>
 );
 
@@ -59,6 +64,11 @@ export const FilledGreyButton = () => (
     <Button size="medium" disabled variant="button-filled-grey">
       Disabled grey button
     </Button>
+    <br />
+    <br />
+    <Button size="medium" isLoading variant="button-filled-grey">
+      Grey button
+    </Button>
   </>
 );
 
@@ -81,6 +91,11 @@ export const FilledDestructiveButton = () => (
     <br />
     <Button size="medium" disabled variant="button-filled-destructive">
       Disabled destructive button
+    </Button>
+    <br />
+    <br />
+    <Button size="medium" isLoading variant="button-filled-destructive">
+      Destructive button
     </Button>
   </>
 );

--- a/packages/zephyr/stories/buttons/GhostButton.stories.tsx
+++ b/packages/zephyr/stories/buttons/GhostButton.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<ButtonProps> = {
     docs: {
       description: {
         component:
-          'Ghost buttons are a secondary type of button.  They are text-focused and useful when you need multiple buttons on a page at once. They are also are often used as subactions on a page such as "save" for a form field vs "share" for the modal. These buttons can always be paired with others, but generally, when using **red** ghost buttons, there should only be one on the page or in the modal at a time, which may be a secondary/optional destructive action. When buttons appear in the same row as other buttons they should all be the same size/height (even if they are different types), but buttons in different areas can be different sizes. Ghost buttons are best used at sizes **extra small** to **medium.**',
+          'Ghost buttons are a secondary type of button.  They are text-focused and useful when you need multiple buttons on a page at once. They are also are often used as subactions on a page such as "save" for a form field vs "share" for the modal. These buttons can always be paired with others, but generally, when using **red** ghost buttons, there should only be one on the page or in the modal at a time, which may be a secondary/optional destructive action. When buttons appear in the same row as other buttons they should all be the same size/height (even if they are different types), but buttons in different areas can be different sizes. Ghost buttons cannot have **isLoading** as true. Ghost buttons are best used at sizes **extra small** to **medium.**',
       },
       page: () => (
         <>

--- a/packages/zephyr/stories/buttons/OutlineButton.stories.tsx
+++ b/packages/zephyr/stories/buttons/OutlineButton.stories.tsx
@@ -1,6 +1,6 @@
 import { Title, Subtitle, Description, Stories } from '@storybook/addon-docs/blocks';
 import React from 'react';
-import { Story, Meta } from '@storybook/react';
+import { Meta } from '@storybook/react';
 import { Button, ButtonProps } from '../../src/Button';
 
 const meta: Meta<ButtonProps> = {
@@ -26,15 +26,20 @@ const meta: Meta<ButtonProps> = {
 
 export default meta;
 
-const Template: Story<ButtonProps> = (args) => <Button {...args} data-testid={meta.title} />;
-
-export const OutlineBlueButton = Template.bind({});
-
-OutlineBlueButton.args = {
-  children: 'Outline blue button',
-  size: 'medium',
-  variant: 'button-outline-blue',
-};
+export const OutlineBlueButton = () => (
+  <>
+    <Button size="medium" variant="button-outline-blue">
+      Outline blue button
+    </Button>
+    <br />
+    <br />
+    <Button isLoading size="medium" variant="button-outline-blue">
+      Outline blue button
+    </Button>
+    <br />
+    <br />
+  </>
+);
 
 OutlineBlueButton.parameters = {
   docs: {
@@ -47,13 +52,20 @@ OutlineBlueButton.parameters = {
 
 OutlineBlueButton.storyName = 'Outline (Blue)';
 
-export const OutlineGreyButton = Template.bind({});
-
-OutlineGreyButton.args = {
-  children: 'Outline grey button',
-  size: 'medium',
-  variant: 'button-outline-grey',
-};
+export const OutlineGreyButton = () => (
+  <>
+    <Button size="medium" variant="button-outline-grey">
+      Outline grey button
+    </Button>
+    <br />
+    <br />
+    <Button isLoading size="medium" variant="button-outline-grey">
+      Outline grey button
+    </Button>
+    <br />
+    <br />
+  </>
+);
 
 OutlineGreyButton.parameters = {
   docs: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4669,6 +4669,11 @@
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
   integrity sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==
 
+"@types/classnames@^2.2.11":
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.11.tgz#2521cc86f69d15c5b90664e4829d84566052c1cf"
+  integrity sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -7322,7 +7327,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==


### PR DESCRIPTION
Add loading state to filled button components
- `isLoading` can only be true for buttons with boundaries (ie. filled and outline buttons)
  - Note: There is currently no `button-outline-destructive` variant
- `invariant` throws dev side error on build if `isLoading` is set to true for ghost or unstyled variants
- Accessibility
  - `useReducedMotion` to [limit animations](https://www.framer.com/api/motion/guide-accessibility/)
  - `VisuallyHidden` for meaningful [loading](https://reach.tech/visually-hidden/) state change on screen readers

All comments and full commit history [here](https://github.com/AirLabsTeam/air-core/pull/69)

[Figma](https://www.figma.com/file/EZ1hzsmsNYblYoBQYvVgEV/Web-Component-Library?node-id=26%3A336) Design spec