### PR TITLE
fix(@air/zephyr): fix button responsive variants and type defs

### DIFF
--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -17,7 +17,7 @@ export type ButtonSize = 'large' | 'medium' | 'small';
  */
 export type NonSemanticButtonProps = Pick<BoxStylingProps, 'tx'> & {
   size?: ButtonSize;
-  variant?: ButtonVariantName;
+  variant?: ButtonVariantName | ButtonVariantName[];
   /**
    * `isLoading` can only be true for buttons with boundaries (ie. filled and outline variants). Note: `button-outline-destructive` is not currently a variant.
    */

--- a/packages/zephyr/src/theme/variants/button.ts
+++ b/packages/zephyr/src/theme/variants/button.ts
@@ -15,6 +15,7 @@ export type ButtonVariantName =
 const _button: { [key in ButtonVariantName]: TXProp } = {
   'button-filled-blue': {
     backgroundColor: 'jay500',
+    border: 'none',
     color: 'white',
     '&:hover:not(.is-loading)': {
       backgroundColor: 'jay600',
@@ -29,6 +30,7 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
   },
   'button-filled-destructive': {
     backgroundColor: 'flamingo600',
+    border: 'none',
     color: 'white',
     '&:hover:not(.is-loading)': {
       backgroundColor: 'flamingo700',
@@ -43,6 +45,7 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
   },
   'button-filled-grey': {
     backgroundColor: 'pigeon050',
+    border: 'none',
     color: 'pigeon600',
     '&:hover:not(.is-loading)': {
       backgroundColor: 'pigeon100',
@@ -102,6 +105,7 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
     },
   },
   'button-outline-blue': {
+    backgroundColor: 'transparent',
     border: '1px solid',
     borderColor: 'jay200',
     color: 'jay500',
@@ -121,6 +125,7 @@ const _button: { [key in ButtonVariantName]: TXProp } = {
     },
   },
   'button-outline-grey': {
+    backgroundColor: 'transparent',
     border: '1px solid',
     borderColor: 'pigeon200',
     color: 'pigeon600',

--- a/packages/zephyr/stories/buttons/Button.stories.tsx
+++ b/packages/zephyr/stories/buttons/Button.stories.tsx
@@ -30,6 +30,12 @@ Default.args = {
   children: 'Button',
 };
 
+export const ButtonResponsiveVariants: Story<ButtonProps> = () => (
+  <Button variant={['button-filled-blue', 'button-outline-blue']}>
+    This button changes to a different variant based on the screen resolution
+  </Button>
+);
+
 export const ButtonAs: Story<ButtonProps> = () => (
   <Button as="a" href="https://google.com" target="_blank">
     This story acts as an integration test asserting that we can render the item as another semantic


### PR DESCRIPTION
## Summary
- Fix css properties getting inherited when using different variant styles in a responsive array
- Fix button variant typescript def