### PR TITLE
form-improvements (from kyle)

### DIFF
--- a/packages/zephyr/src/Forms/Input.tsx
+++ b/packages/zephyr/src/Forms/Input.tsx
@@ -284,7 +284,7 @@ export const Input = ({
         {/* For screen reader users, provide context as to which field is erroring */}
         {meta.error && <VisuallyHidden>{`Error on ${label} input: `}</VisuallyHidden>}
 
-        <span aria-hidden="true">{capitalize(meta.error)}</span>
+        {capitalize(meta.error)}
       </Text>
     </Box>
   );

--- a/packages/zephyr/src/Forms/Input.tsx
+++ b/packages/zephyr/src/Forms/Input.tsx
@@ -254,6 +254,7 @@ export const Input = ({
         as="span"
         id={descriptionIdentifier}
         variant="text-ui-12"
+        data-testid={`${topLevelTestID}_description`}
         tx={{
           ...sharedBottomTextStyles,
           display: hasError ? 'none' : 'block',
@@ -272,6 +273,7 @@ export const Input = ({
         id={errorIdentifier}
         role="alert"
         variant="text-ui-12"
+        data-testid={`${topLevelTestID}_error`}
         tx={{
           ...sharedBottomTextStyles,
           display: hasError ? 'block' : 'none',
@@ -282,7 +284,7 @@ export const Input = ({
         {/* For screen reader users, provide context as to which field is erroring */}
         {meta.error && <VisuallyHidden>{`Error on ${label} input: `}</VisuallyHidden>}
 
-        {capitalize(meta.error)}
+        <span aria-hidden="true">{capitalize(meta.error)}</span>
       </Text>
     </Box>
   );

--- a/packages/zephyr/src/Forms/SingleSelect.tsx
+++ b/packages/zephyr/src/Forms/SingleSelect.tsx
@@ -564,7 +564,7 @@ export const SingleSelect = ({
         {/* For screen reader users, provide context as to which field is erroring */}
         {meta.error && <VisuallyHidden>{`Error on ${label} input: `}</VisuallyHidden>}
 
-        <span aria-hidden="true">{capitalize(meta.error)}</span>
+        {capitalize(meta.error)}
       </Text>
     </Box>
   );

--- a/packages/zephyr/src/Forms/SingleSelect.tsx
+++ b/packages/zephyr/src/Forms/SingleSelect.tsx
@@ -534,6 +534,7 @@ export const SingleSelect = ({
         as="span"
         id={descriptionID}
         variant="text-ui-12"
+        data-testid={`${testID}_description`}
         tx={{
           ...sharedBottomTextStyles,
           display: hasError ? 'none' : 'block',
@@ -552,6 +553,7 @@ export const SingleSelect = ({
         id={errorID}
         role="alert"
         variant="text-ui-12"
+        data-testid={`${testID}_error`}
         tx={{
           ...sharedBottomTextStyles,
           display: hasError ? 'block' : 'none',
@@ -562,7 +564,7 @@ export const SingleSelect = ({
         {/* For screen reader users, provide context as to which field is erroring */}
         {meta.error && <VisuallyHidden>{`Error on ${label} input: `}</VisuallyHidden>}
 
-        {capitalize(meta.error)}
+        <span aria-hidden="true">{capitalize(meta.error)}</span>
       </Text>
     </Box>
   );


### PR DESCRIPTION
… single selects, plus a11y fix

Ensured that the testid prop also constructs testids for the description element + the error element
when rendered.

Additionally, prevented screen readers from hearing error twice.