### PR TITLE
fix: add class to GoogleDrive paths to avoid merging them

### DIFF
--- a/packages/icons/src/svgs/uncategorized/GoogleDrive.svg
+++ b/packages/icons/src/svgs/uncategorized/GoogleDrive.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 32 32">
-    <path d="M8.00024 26.5729L11.9999 19.9062H28L23.9999 26.5729H8.00024Z" fill="currentColor"/>
-    <path d="M20.0002 19.9063H28L20.0002 6.573H11.9999L20.0002 19.9063Z" fill="currentColor"/>
-    <path d="M4 19.9063L8.00025 26.5729L16 13.2397L11.9999 6.573L4 19.9063Z" fill="currentColor"/>
+    <path fill="currentColor" d="M8 26.573l4-6.667h16l-4 6.667H8z" class="GoogleDrive_svg_GoogleDrive_svg_path1"/>
+    <path fill="currentColor" d="M20 19.906h8L20 6.573h-8l8 13.333z" class="GoogleDrive_svg_GoogleDrive_svg_path2"/>
+    <path fill="currentColor" d="M4 19.906l4 6.667 8-13.333-4-6.667-8 13.333z" class="GoogleDrive_svg_GoogleDrive_svg_path3"/>
 </svg>


### PR DESCRIPTION
I add `class` attribute to each path, since `id` did not prevent merging