### PR TITLE
For IconButton, rename "hiddenLabel" prop to "children"

### DIFF
--- a/packages/zephyr/src/IconButton.tsx
+++ b/packages/zephyr/src/IconButton.tsx
@@ -9,7 +9,15 @@ import { Button, ButtonProps, NonSemanticButtonProps } from './Button';
 export interface NonSemanticIconButtonProps extends NonSemanticButtonProps {
   icon: (props?: React.SVGProps<SVGElement> | undefined) => JSX.Element;
   hasTooltip: boolean;
-  hiddenLabel: string;
+
+  /**
+   * Unlike usual, this prop only accepts a string. It is also never visible. It represents an accessible label when the
+   * button is not wrapped by a Tooltip. You may ask: "Why not name this prop better, and not use 'children'"?. Many
+   * a11y-first libraries we consume like @reach-ui and @radix-ui have adopted this pattern of expecting required
+   * accessibility text as a 'children' prop. When we use the polymorphic 'as' prop for things like MenuButton, 'children'
+   * would be required.
+   */
+  children: string;
 }
 
 export interface IconButtonProps
@@ -20,10 +28,10 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
   (
     {
       as = 'button',
+      children,
       className,
       disabled = false,
       hasTooltip,
-      hiddenLabel,
       icon,
       isLoading = false,
       size = 'medium',
@@ -73,7 +81,7 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
         variant={variant}
       >
         {/* If button is wrapped with tooltip, it doesn't require assistive text. It's already provided on focus via the tooltip. */}
-        {!hasTooltip && <VisuallyHidden>{hiddenLabel}</VisuallyHidden>}
+        {!hasTooltip && <VisuallyHidden>{children}</VisuallyHidden>}
         <Box
           as={icon}
           tx={{

--- a/packages/zephyr/src/XButton.tsx
+++ b/packages/zephyr/src/XButton.tsx
@@ -4,7 +4,7 @@ import { X_BUTTON } from './testIDs';
 import { IconButton, IconButtonProps, NonSemanticIconButtonProps } from './IconButton';
 
 export interface XButtonProps
-  extends Optional<NonSemanticIconButtonProps, 'hiddenLabel'>,
+  extends Optional<NonSemanticIconButtonProps, 'children'>,
     Pick<IconButtonProps, 'onClick' | 'ref' | 'size' | 'variant' | 'tx'> {}
 
 /**
@@ -13,7 +13,7 @@ export interface XButtonProps
 export const XButton = React.forwardRef<HTMLButtonElement, XButtonProps>(
   (
     {
-      hiddenLabel = 'Close Modal',
+      children = 'Close Modal',
       onClick,
       size = 'extra-small',
       tx,
@@ -24,14 +24,15 @@ export const XButton = React.forwardRef<HTMLButtonElement, XButtonProps>(
     <IconButton
       data-testid={X_BUTTON}
       hasTooltip={false}
-      hiddenLabel={hiddenLabel}
       icon={Close}
       onClick={onClick}
       ref={ref}
       size={size}
       tx={{ position: 'absolute', color: 'pigeon400', top: 16, right: 24, ...tx }}
       variant={variant}
-    />
+    >
+      {children}
+    </IconButton>
   ),
 );
 

--- a/packages/zephyr/stories/buttons/IconButton.stories.tsx
+++ b/packages/zephyr/stories/buttons/IconButton.stories.tsx
@@ -66,13 +66,9 @@ export const AllPossibleIconButtons: Story<IconButtonProps> = () => {
                       {label}
                     </Text>
 
-                    <IconButton
-                      hasTooltip={false}
-                      hiddenLabel="See Notifications"
-                      icon={Bell}
-                      size={size}
-                      variant={variant}
-                    />
+                    <IconButton hasTooltip={false} icon={Bell} size={size} variant={variant}>
+                      See Notifications
+                    </IconButton>
                   </Box>
                 );
               })}


### PR DESCRIPTION
Was working on integrating IconButton in the app repo when suddenly...

![Screen Shot 2021-03-05 at 8 06 43 PM](https://user-images.githubusercontent.com/9523719/110194761-089b8e00-7def-11eb-9c12-dfbb2dad2f4b.png)

BREAKING CHANGE

... but we dont use this yet so it wont hurt ❤️ 