### PR TITLE
fix(@air/zephyr): fix additional spacing above menu item

### DIFF
--- a/packages/zephyr/src/Menus/components/MenuItem.tsx
+++ b/packages/zephyr/src/Menus/components/MenuItem.tsx
@@ -63,7 +63,6 @@ export const MenuItem = ({
           backgroundColor: 'transparent',
           height: hasDescription ? 'auto' : isSmallSize ? 32 : 36,
           mb: hasDividerBottom ? 0 : 8,
-          mt: hasDividerTop ? 0 : 8,
           px: 6,
           py: hasDescription ? 6 : 0,
           border: 0,


### PR DESCRIPTION
Can't believe I didn't notice this in Chromatic 🤦 

- Remove `mt` spacing from `MenuItem`