### PR TITLE
chore: export menu item label and description for reuse

### DIFF
--- a/packages/zephyr/src/Menus/components/MenuItem.tsx
+++ b/packages/zephyr/src/Menus/components/MenuItem.tsx
@@ -4,6 +4,8 @@ import { Box, BoxProps } from '../../Box';
 import { Text } from '../../Text';
 import { MenuSize } from './Menu';
 import { MenuDivider } from './MenuDivider';
+import { MenuItemDescription } from './MenuItemDescription';
+import { MenuItemLabel } from './MenuItemLabel';
 
 export type MenuItemRenderProps =
   | { children: ReactNode }
@@ -94,23 +96,12 @@ export const MenuItem = ({
             restOfProps.children
           ) : (
             <Box>
-              <Text
-                tx={{
-                  color: 'inherit',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-                variant={isSmallSize ? 'text-ui-14' : 'text-ui-16'}
-              >
+              <MenuItemLabel variant={isSmallSize ? 'text-ui-14' : 'text-ui-16'}>
                 {restOfProps.label}
-              </Text>
-              <Text
-                tx={{ mt: 2, color: 'pigeon500' }}
-                variant={isSmallSize ? 'text-ui-12' : 'text-ui-14'}
-              >
+              </MenuItemLabel>
+              <MenuItemDescription variant={isSmallSize ? 'text-ui-12' : 'text-ui-14'}>
                 {restOfProps.description}
-              </Text>
+              </MenuItemDescription>
             </Box>
           )}
         </Box>

--- a/packages/zephyr/src/Menus/components/MenuItemDescription.tsx
+++ b/packages/zephyr/src/Menus/components/MenuItemDescription.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Text, TextProps } from '../../Text';
+
+export const MenuItemDescription = ({ tx, ...restOfProps }: TextProps) => (
+  <Text tx={{ mt: 2, color: 'pigeon500', ...(tx as any) }} variant="text-ui-14" {...restOfProps} />
+);

--- a/packages/zephyr/src/Menus/components/MenuItemLabel.tsx
+++ b/packages/zephyr/src/Menus/components/MenuItemLabel.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Text, TextProps } from '../../Text';
+
+export const MenuItemLabel = ({ tx, ...rest }: TextProps) => (
+  <Text
+    tx={{
+      color: 'inherit',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      ...(tx as any),
+    }}
+    variant="text-ui-16"
+    {...rest}
+  />
+);

--- a/packages/zephyr/src/Menus/index.tsx
+++ b/packages/zephyr/src/Menus/index.tsx
@@ -4,3 +4,5 @@ export * from './abstractions/DropdownMenu';
 export * from './components/Menu';
 export * from './components/MenuDivider';
 export * from './components/MenuItem';
+export * from './components/MenuItemLabel';
+export * from './components/MenuItemDescription';


### PR DESCRIPTION
Broke out `MenuItemLabel` and `MenuItemDescription` into separate components so the consumers can re-use them and style them if needed