### PR TITLE
Remove modal content Text wrapper

### DIFF
--- a/packages/zephyr/src/Modals/Modal.tsx
+++ b/packages/zephyr/src/Modals/Modal.tsx
@@ -253,7 +253,7 @@ export const Modal = ({
           </Box>
         )}
 
-        <Text variant="text-ui-16">{children}</Text>
+        {children}
       </ModalContent>
     </ModalOverlay>
   );

--- a/packages/zephyr/src/Modals/Modal.tsx
+++ b/packages/zephyr/src/Modals/Modal.tsx
@@ -253,7 +253,7 @@ export const Modal = ({
           </Box>
         )}
 
-        {children}
+        <Text variant="text-ui-16">{children}</Text>
       </ModalContent>
     </ModalOverlay>
   );


### PR DESCRIPTION
By having this extra element, it breaks potential usages of `display: flex` with their consumers who might be trying to utilize `flex: 1` to get the content to take up the full width of the modal