### PR TITLE
fix: s4 - SingleSelect cuts off g

### DIFF
--- a/packages/zephyr/src/Forms/SingleSelect.tsx
+++ b/packages/zephyr/src/Forms/SingleSelect.tsx
@@ -291,6 +291,7 @@ export const getBaseSelectStylesWithTheme = ({
   }),
   valueContainer: (base) => ({
     ...base,
+    height: '100%',
     padding: 0,
   }),
 });

--- a/packages/zephyr/stories/forms/SingleSelect.stories.tsx
+++ b/packages/zephyr/stories/forms/SingleSelect.stories.tsx
@@ -16,6 +16,7 @@ import { FieldVariantName, field } from '../../src/theme/variants/field';
 const variants = Object.keys(field) as FieldVariantName[];
 
 const options: SelectOption[] = [
+  { label: 'Big Fish', value: 'bgf' },
   { label: 'Red Fish', value: 'rf' },
   { label: 'Blue Fish', value: 'bf' },
   { label: 'Green Fish', value: 'gf' },
@@ -117,6 +118,7 @@ Default.args = {
   // name: 'default', purposefully not defined here (see story JSX)
   required: true,
   options,
+  isSearchable: false,
 };
 
 Default.parameters = {


### PR DESCRIPTION
base styles from react-select provide 16px height for non-searchable single-select, and 24px for searchable. No reason for either height, 100% works fine in both cases.