### PR TITLE
feat: allow object syntax use with TertiaryCTAs

### DIFF
--- a/packages/zephyr/src/Modals/TransactionModal.tsx
+++ b/packages/zephyr/src/Modals/TransactionModal.tsx
@@ -74,6 +74,16 @@ export const TransactionModal = ({
     secondaryCTA
   );
 
+  const tertiaryCTAElement = !tertiaryCTA ? null : isUsingButtonSchema(tertiaryCTA) ? (
+    <Button
+      variant="button-ghost-destructive"
+      data-testid={TRANSACTION_MODAL_TERTIARY_CTA}
+      {...tertiaryCTA}
+    />
+  ) : (
+    tertiaryCTA
+  );
+
   return (
     <Modal
       className={className}
@@ -103,7 +113,7 @@ export const TransactionModal = ({
               alignItems: 'center',
             }}
           >
-            {tertiaryCTA}
+            {tertiaryCTAElement}
           </Box>
         )}
         <Box tx={{ '& > *:first-child': { mr: 12 } }}>

--- a/packages/zephyr/stories/modals/TransactionModal.stories.tsx
+++ b/packages/zephyr/stories/modals/TransactionModal.stories.tsx
@@ -139,6 +139,16 @@ export const TertiaryTransactionModal: Story<TransactionModalProps> = () => {
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
 
+  const defaultTertiaryCTA = {
+    children: 'Default CTA',
+    onClick: () => setIsChecked(true),
+    'data-testid': 'MY_CUSTOM_TERTIARY_TEST_ID',
+  };
+
+  const checkboxTertiaryCTA = (
+    <Checkbox label="Custom CTA Checkbox" checked={false} onChange={() => setIsChecked(false)} />
+  );
+
   return (
     <>
       <Button type="button" onClick={openModal} variant="button-filled-blue">
@@ -148,13 +158,7 @@ export const TertiaryTransactionModal: Story<TransactionModalProps> = () => {
       <AnimatePresence>
         {isModalOpen && (
           <TransactionModal
-            tertiaryCTA={
-              <Checkbox
-                label="Apply for all items"
-                checked={isChecked}
-                onChange={() => setIsChecked(!isChecked)}
-              />
-            }
+            tertiaryCTA={isChecked ? checkboxTertiaryCTA : defaultTertiaryCTA}
             onDismiss={closeModal}
             modalLabel="Uh oh! You have duplicates"
             modalDescription="3 out of 3 of the items you'd like to upload already exist. What would you like to do for item 1 of 3?"


### PR DESCRIPTION
### Changes
- allows object syntax to be used for tertiaryCTAs on the TransactionModal
  - This does mean we needed to pick a default button so we went with the destructive since it's the one most likely to be used (and it is distinctly different from the other CTAs)