### PR TITLE
fix/conditionally display field error on Input

### DIFF
--- a/packages/zephyr/src/Forms/Input.tsx
+++ b/packages/zephyr/src/Forms/Input.tsx
@@ -169,17 +169,17 @@ export interface InputProps {
     InnerInput?: TXProp;
     InnerInputContainer?: TXProp;
   };
-  disabled?: boolean;
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  readOnly?: boolean;
-  'data-testid'?: string;
-  innerInputRef?: React.MutableRefObject<HTMLInputElement | null>;
   /**
    * This is a formik based component. As a result, this input has access to it's specific error message. By default, this value is set to true and any
    * errors incurred by this component will display below the input field. If you'd like to use alternative tools to handle displaying your errors (i.e. Formik's `<ErrorMessage>`
    * component), then you should set this prop to false to prevent duplicate, or ill-formatted error messages.
    */
-  showFormikError?: boolean;
+  displayFormikError?: boolean;
+  disabled?: boolean;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  readOnly?: boolean;
+  'data-testid'?: string;
+  innerInputRef?: React.MutableRefObject<HTMLInputElement | null>;
 }
 
 const sharedAdornmentStyles: BoxStylingProps['tx'] = {
@@ -202,7 +202,7 @@ export const Input = ({
   placeholder,
   readOnly = false,
   required,
-  showFormikError = true,
+  displayFormikError = true,
   tx = {},
   type = 'text',
   variant = 'field-input-smol',
@@ -394,7 +394,7 @@ export const Input = ({
         )}
       </Text>
 
-      {showFormikError && (
+      {displayFormikError && (
         <Error
           errorText={meta.error}
           isErrorVisible={hasError}

--- a/packages/zephyr/src/Forms/Input.tsx
+++ b/packages/zephyr/src/Forms/Input.tsx
@@ -174,6 +174,12 @@ export interface InputProps {
   readOnly?: boolean;
   'data-testid'?: string;
   innerInputRef?: React.MutableRefObject<HTMLInputElement | null>;
+  /**
+   * This is a formik based component. As a result, this input has access to it's specific error message. By default, this value is set to true and any
+   * errors incurred by this component will display below the input field. If you'd like to use alternative tools to handle displaying your errors (i.e. Formik's `<ErrorMessage>`
+   * component), then you should set this prop to false to prevent duplicate, or ill-formatted error messages.
+   */
+  showFormikError?: boolean;
 }
 
 const sharedAdornmentStyles: BoxStylingProps['tx'] = {
@@ -196,6 +202,7 @@ export const Input = ({
   placeholder,
   readOnly = false,
   required,
+  showFormikError = true,
   tx = {},
   type = 'text',
   variant = 'field-input-smol',
@@ -387,13 +394,15 @@ export const Input = ({
         )}
       </Text>
 
-      <Error
-        errorText={meta.error}
-        isErrorVisible={hasError}
-        id={errorIdentifier}
-        tx={{ bottom: isChonky ? -22 : -18 }}
-        data-testid={`${topLevelTestID}_error`}
-      />
+      {showFormikError && (
+        <Error
+          errorText={meta.error}
+          isErrorVisible={hasError}
+          id={errorIdentifier}
+          tx={{ bottom: isChonky ? -22 : -18 }}
+          data-testid={`${topLevelTestID}_error`}
+        />
+      )}
     </Box>
   );
 };

--- a/packages/zephyr/src/Forms/Input.tsx
+++ b/packages/zephyr/src/Forms/Input.tsx
@@ -170,11 +170,11 @@ export interface InputProps {
     InnerInputContainer?: TXProp;
   };
   /**
-   * This is a formik based component. As a result, this input has access to it's specific error message. By default, this value is set to true and any
+   * This is a formik based component. As a result, this input has access to its specific error message. By default, this value is set to false and any
    * errors incurred by this component will display below the input field. If you'd like to use alternative tools to handle displaying your errors (i.e. Formik's `<ErrorMessage>`
    * component), then you should set this prop to false to prevent duplicate, or ill-formatted error messages.
    */
-  displayFormikError?: boolean;
+  isErrorHidden?: boolean;
   disabled?: boolean;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   readOnly?: boolean;
@@ -202,7 +202,7 @@ export const Input = ({
   placeholder,
   readOnly = false,
   required,
-  displayFormikError = true,
+  isErrorHidden = false,
   tx = {},
   type = 'text',
   variant = 'field-input-smol',
@@ -394,7 +394,7 @@ export const Input = ({
         )}
       </Text>
 
-      {displayFormikError && (
+      {!isErrorHidden && (
         <Error
           errorText={meta.error}
           isErrorVisible={hasError}


### PR DESCRIPTION
### Changes

- Conditionally displays the specific formikError on the Input
  - This is needed because if we want to display the error on a field, in a place that is **_not_** right below the input, (i.e. using Formik's `ErrorMessage` component) this Input component will still display its error. In which case we end up showing duplicate (and potentially ill-formatted) error messages