### PR TITLE
task/allow iconButton to render tooltip

### DIFF
--- a/packages/zephyr/src/IconButton.tsx
+++ b/packages/zephyr/src/IconButton.tsx
@@ -3,15 +3,13 @@ import { forwardRefWithAs } from '@reach/utils';
 import VisuallyHidden from '@reach/visually-hidden';
 import { variant as styledSystemVariant } from 'styled-system';
 import { useTheme } from 'styled-components';
+import { Tooltip, TooltipProps } from '../src/Tooltip';
 import { Box } from './Box';
 import { Button, ButtonProps, NonSemanticButtonProps } from './Button';
 import { SVGComponent } from './shared';
 
 export interface NonSemanticIconButtonProps
   extends Omit<NonSemanticButtonProps, 'children' | 'adornmentLeft' | 'adornmentRight'> {
-  icon: SVGComponent;
-  hasTooltip: boolean;
-
   /**
    * Unlike usual, this prop only accepts a string. It is also never visible. It represents an accessible label when the
    * button is not wrapped by a Tooltip. You may ask: "Why not name this prop better, and not use 'children'"?. Many
@@ -20,6 +18,11 @@ export interface NonSemanticIconButtonProps
    * would be required.
    */
   children: string;
+  icon: SVGComponent;
+  /**
+   * If you would like for the button to have its own tooltip, you can pass in the necessary props and the tooltip will be rendered immediately outside the IconButton, with the contents of this prop spread onto the Tooltip component.
+   */
+  tooltip?: Omit<TooltipProps, 'children'>;
 }
 
 export interface IconButtonProps
@@ -33,7 +36,7 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
       children,
       className,
       disabled = false,
-      hasTooltip,
+      tooltip: tooltipProps,
       icon,
       isLoading = false,
       size = 'medium',
@@ -46,7 +49,7 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
   ) => {
     const theme = useTheme();
 
-    return (
+    const iconButton = (
       <Button
         {...restOfProps}
         as={as}
@@ -90,7 +93,7 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
         variant={variant}
       >
         {/* If button is wrapped with tooltip, it doesn't require assistive text. It's already provided on focus via the tooltip. */}
-        {!hasTooltip && <VisuallyHidden>{children}</VisuallyHidden>}
+        {!tooltipProps && <VisuallyHidden>{children}</VisuallyHidden>}
         <Box
           as={icon}
           tx={{
@@ -118,5 +121,7 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
         />
       </Button>
     );
+
+    return tooltipProps ? <Tooltip {...tooltipProps}>{iconButton}</Tooltip> : iconButton;
   },
 );

--- a/packages/zephyr/stories/buttons/IconButton.stories.tsx
+++ b/packages/zephyr/stories/buttons/IconButton.stories.tsx
@@ -18,9 +18,8 @@ const meta: Meta<IconButtonProps> = {
   parameters: {
     docs: {
       description: {
-        component: `\`<IconButton>\` is meant for use when the only content within the button is an icon. Sometimes,
-an \`<IconButton>\` is rendered within a \`<Tooltip>\` component. In those instances, the \`hasTooltip\` prop should
-be "true" so that the assistive label is not read twice to users with assistive technology.`,
+        component:
+          '`<IconButton>` is meant for use when the only content within the button is an icon. You can pass it a tooltip if you would like, using the `tooltip` prop.',
       },
       page: () => (
         <>
@@ -66,7 +65,12 @@ export const AllPossibleIconButtons: Story<IconButtonProps> = () => {
                       {label}
                     </Text>
 
-                    <IconButton hasTooltip={false} icon={Bell} size={size} variant={variant}>
+                    <IconButton
+                      icon={Bell}
+                      size={size}
+                      variant={variant}
+                      tooltip={{ side: 'top', label: 'Bell' }}
+                    >
                       See Notifications
                     </IconButton>
                   </Box>


### PR DESCRIPTION
- [Notion Link](https://www.notion.so/airinc/Frontend-3182e6ca45c7469eb0cf7295f925f383?p=2beee74eb7474bd28f603b80e24da4ba)

### Changes 
- Removes the `hasTooltip` prop from IconButton (this is a breaking change)
- Adds a `tooltip` prop on the IconButton to allow passing in the props needed for the IconButton to render a tooltip