### PR TITLE
feat/tooltip prop on IconButton

### DIFF
--- a/packages/zephyr/src/IconButton.tsx
+++ b/packages/zephyr/src/IconButton.tsx
@@ -3,6 +3,7 @@ import VisuallyHidden from '@reach/visually-hidden';
 import { variant as styledSystemVariant } from 'styled-system';
 import { Ref } from 'react';
 import { useTheme } from 'styled-components';
+import { Tooltip, TooltipProps } from '../src/Tooltip';
 import { Box } from './Box';
 import { Button, ButtonProps, NonSemanticButtonProps } from './Button';
 import { SVGComponent } from './shared';
@@ -18,7 +19,14 @@ export interface NonSemanticIconButtonProps
    */
   children: string;
   icon: SVGComponent;
-  hasTooltip: boolean;
+  /**
+   * If you would like for the button to have its own tooltip, you can pass in the necessary props and the tooltip will be rendered immediately outside the IconButton, with the contents of this prop spread onto the Tooltip component.
+   */
+  tooltip?: Pick<TooltipProps, 'label' | 'side'> & Omit<TooltipProps, 'children'>;
+  /**
+   * When this prop is set to  false, the assistive text is hidden. It should be set to true when an IconButton is wrapped in a tree where a Tooltip is wrapped around the parent element.
+   */
+  hideAssistiveText?: boolean;
 }
 
 export interface IconButtonProps
@@ -32,9 +40,10 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
       children,
       className,
       disabled = false,
-      hasTooltip,
+      tooltip,
       icon,
       isLoading = false,
+      hideAssistiveText = false,
       size = 'medium',
       tx,
       type = 'button',
@@ -89,7 +98,7 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
         variant={variant}
       >
         {/* If button is wrapped with tooltip, it doesn't require assistive text. It's already provided on focus via the tooltip. */}
-        {!hasTooltip && <VisuallyHidden>{children}</VisuallyHidden>}
+        {(!tooltip || hideAssistiveText) && <VisuallyHidden>{children}</VisuallyHidden>}
         <Box
           as={icon}
           tx={{
@@ -118,6 +127,6 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
       </Button>
     );
 
-    return iconButton;
+    return tooltip ? <Tooltip {...tooltip}>{iconButton}</Tooltip> : iconButton;
   },
 );

--- a/packages/zephyr/src/IconButton.tsx
+++ b/packages/zephyr/src/IconButton.tsx
@@ -24,9 +24,9 @@ export interface NonSemanticIconButtonProps
    */
   tooltip?: Pick<TooltipProps, 'label' | 'side'> & Omit<TooltipProps, 'children'>;
   /**
-   * When this prop is set to  false, the assistive text is hidden. It should be set to true when an IconButton is wrapped in a tree where a Tooltip is wrapped around the parent element.
+   * When this prop is set to `false`, the assistive text is hidden. By default this is `true`. This should only be set to `false` when an iconButton has a parent element that already has a tooltip. In this case, assistive text is not required because a tooltip is present.
    */
-  hideAssistiveText?: boolean;
+  showAssistiveText?: boolean;
 }
 
 export interface IconButtonProps
@@ -43,7 +43,7 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
       tooltip,
       icon,
       isLoading = false,
-      hideAssistiveText = false,
+      showAssistiveText = true,
       size = 'medium',
       tx,
       type = 'button',
@@ -53,6 +53,7 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
     ref: Ref<HTMLButtonElement>,
   ) => {
     const theme = useTheme();
+    const shouldShowAssistiveText = !tooltip && showAssistiveText;
 
     const iconButton = (
       <Button
@@ -98,7 +99,7 @@ export const IconButton = forwardRefWithAs<NonSemanticIconButtonProps, 'button'>
         variant={variant}
       >
         {/* If button is wrapped with tooltip, it doesn't require assistive text. It's already provided on focus via the tooltip. */}
-        {(!tooltip || hideAssistiveText) && <VisuallyHidden>{children}</VisuallyHidden>}
+        {shouldShowAssistiveText && <VisuallyHidden>{children}</VisuallyHidden>}
         <Box
           as={icon}
           tx={{

--- a/packages/zephyr/src/Tooltip.tsx
+++ b/packages/zephyr/src/Tooltip.tsx
@@ -7,9 +7,9 @@ import { Box } from './Box';
 import { Text } from './Text';
 import { TXProp } from './theme';
 /**
- * This type is necessary but it is not exported from @radix-ui/react-popper so we duplicate it here
+ * This type is necessary, but it is not exported from @radix-ui/react-popper, so we duplicate it here using the pieces of the package that are exported
  */
-type DuplicatePopperOwnProps = {
+type PopperOwnProps = {
   anchorRef: React.RefObject<Measurable>;
   side?: Side;
   sideOffset?: number;
@@ -19,8 +19,7 @@ type DuplicatePopperOwnProps = {
   avoidCollisions?: boolean;
 };
 
-export interface TooltipProps
-  extends Omit<DuplicatePopperOwnProps, 'anchorRef' | 'sideOffset' | 'side'> {
+export interface TooltipProps extends Omit<PopperOwnProps, 'anchorRef' | 'sideOffset' | 'side'> {
   /**
    * Must be a real element to attach the tooltip to. This can either be a node, an element, or a component whose ref
    * is properly forwarded.

--- a/packages/zephyr/src/Tooltip.tsx
+++ b/packages/zephyr/src/Tooltip.tsx
@@ -7,7 +7,7 @@ import { Box } from './Box';
 import { Text } from './Text';
 import { TXProp } from './theme';
 /**
- * This type is necessary, but it is not exported from @radix-ui/react-popper, so we duplicate it here using the pieces of the package that are exported
+ * This type is necessary, but it is not exported from @radix-ui/react-popper, so we duplicate it
  */
 type PopperOwnProps = {
   anchorRef: React.RefObject<Measurable>;

--- a/packages/zephyr/src/Tooltip.tsx
+++ b/packages/zephyr/src/Tooltip.tsx
@@ -1,13 +1,24 @@
 import { ComponentProps, FC, ReactNode, ReactElement } from 'react';
 import * as RadixTooltip from '@radix-ui/react-tooltip';
-import { PopperOwnProps } from '@radix-ui/react-popper';
 import { Slot } from '@radix-ui/react-slot';
-import { Side } from '@radix-ui/popper';
+import { Side, Align } from '@radix-ui/popper';
+import { Measurable } from '@radix-ui/rect';
 import { Box } from './Box';
 import { Text } from './Text';
 import { TXProp } from './theme';
 
-export interface TooltipProps extends Omit<PopperOwnProps, 'anchorRef' | 'sideOffset' | 'side'> {
+export type DuplicatedPopperOwnProps = {
+  anchorRef: React.RefObject<Measurable>;
+  side?: Side;
+  sideOffset?: number;
+  align?: Align;
+  alignOffset?: number;
+  collisionTolerance?: number;
+  avoidCollisions?: boolean;
+};
+
+export interface TooltipProps
+  extends Omit<DuplicatedPopperOwnProps, 'anchorRef' | 'sideOffset' | 'side'> {
   /**
    * Must be a real element to attach the tooltip to. This can either be a node, an element, or a component whose ref
    * is properly forwarded.

--- a/packages/zephyr/src/Tooltip.tsx
+++ b/packages/zephyr/src/Tooltip.tsx
@@ -6,8 +6,10 @@ import { Measurable } from '@radix-ui/rect';
 import { Box } from './Box';
 import { Text } from './Text';
 import { TXProp } from './theme';
-
-export type DuplicatedPopperOwnProps = {
+/**
+ * This type is necessary but it is not exported from @radix-ui/react-popper so we duplicate it here
+ */
+type DuplicatePopperOwnProps = {
   anchorRef: React.RefObject<Measurable>;
   side?: Side;
   sideOffset?: number;
@@ -18,7 +20,7 @@ export type DuplicatedPopperOwnProps = {
 };
 
 export interface TooltipProps
-  extends Omit<DuplicatedPopperOwnProps, 'anchorRef' | 'sideOffset' | 'side'> {
+  extends Omit<DuplicatePopperOwnProps, 'anchorRef' | 'sideOffset' | 'side'> {
   /**
    * Must be a real element to attach the tooltip to. This can either be a node, an element, or a component whose ref
    * is properly forwarded.

--- a/packages/zephyr/stories/Tooltip.stories.tsx
+++ b/packages/zephyr/stories/Tooltip.stories.tsx
@@ -3,9 +3,11 @@ import { Meta, Story } from '@storybook/react';
 import isChromatic from 'chromatic/isChromatic';
 import { StoryFnReactReturnType } from '@storybook/react/dist/ts3.9/client/preview/types';
 import { noop } from 'lodash';
+import { Bell } from '@air/icons';
 import { Text } from '../src/Text';
 import { Tooltip, TooltipProps } from '../src/Tooltip';
 import { Box, BoxStylingProps } from '../src/Box';
+import { IconButton } from '../src';
 import { Button } from '../src/Button';
 
 const TooltipStoryDecorator = (Story: () => StoryFnReactReturnType) => (
@@ -213,6 +215,39 @@ export const WithoutArrow = () => {
         Hover over me to see a tooltip without an arrow
       </Button>
     </Tooltip>
+  );
+};
+
+export const AsPropOnIconButton = () => {
+  return (
+    <IconButton
+      icon={Bell}
+      size="medium"
+      variant="button-filled-grey"
+      tooltip={{
+        label: 'Bell',
+        side: 'top',
+      }}
+    >
+      See Notifications
+    </IconButton>
+  );
+};
+
+export const AsPropOnIconButtonUsingManualControlProps = () => {
+  return (
+    <IconButton
+      icon={Bell}
+      size="medium"
+      variant="button-filled-grey"
+      tooltip={{
+        label: 'Bell',
+        side: 'top',
+        manualControlProps: { open: true, defaultOpen: false, onOpenChange: noop },
+      }}
+    >
+      See Notifications
+    </IconButton>
   );
 };
 

--- a/packages/zephyr/stories/buttons/IconButton.stories.tsx
+++ b/packages/zephyr/stories/buttons/IconButton.stories.tsx
@@ -64,7 +64,12 @@ export const AllPossibleIconButtons: Story<IconButtonProps> = () => {
                       {label}
                     </Text>
 
-                    <IconButton icon={Bell} size={size} variant={variant} hasTooltip={false}>
+                    <IconButton
+                      icon={Bell}
+                      size={size}
+                      variant={variant}
+                      tooltip={{ label: 'Bell', side: 'top' }}
+                    >
                       See Notifications
                     </IconButton>
                   </Box>


### PR DESCRIPTION
[Notion Link](https://www.notion.so/airinc/Frontend-3182e6ca45c7469eb0cf7295f925f383?p=2beee74eb7474bd28f603b80e24da4ba)

### Changes
- adds `tooltip` and `showAssistiveText` prop on IconButton
- BREAKING CHANGE: removes the hasTooltip prop