### PR TITLE
Fix: ButtonLink

### DIFF
--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -18,9 +18,6 @@ export type ButtonSize = 'extra-small' | 'small' | 'medium' | 'large';
 export type NonSemanticButtonProps = Pick<BoxStylingProps, 'tx'> & {
   size?: ButtonSize | ButtonSize[];
   variant?: ButtonVariantName | ButtonVariantName[];
-  /**
-   * `isLoading` can only be true for buttons with boundaries (ie. filled and outline variants). Note: `button-outline-destructive` is not currently a variant.
-   */
   isLoading?: boolean;
   adornmentLeft?: SVGComponent;
   adornmentRight?: SVGComponent;

--- a/packages/zephyr/src/ButtonLink.tsx
+++ b/packages/zephyr/src/ButtonLink.tsx
@@ -1,19 +1,23 @@
 import { noop } from 'lodash';
+import { forwardRefWithAs, PropsWithAs } from '@reach/utils';
+import { Ref } from 'react';
 import { useTheme } from 'styled-components';
 
-import { Box, BoxProps } from './Box';
+import { Box, BoxStylingProps } from './Box';
 import { Text } from './Text';
 import { ButtonLinkVariantName, TextVariantName } from './theme';
 
 type ButtonLinkSize = 'large' | 'medium' | 'small';
 
-export interface ButtonLinkProps
-  extends Pick<BoxProps<'button' | 'a'>, 'as' | 'children' | 'onClick' | 'tx'> {
+export type NonSemanticButtonLinkProps = Pick<BoxStylingProps, 'tx'> & {
+  /** We need to define the `disabled` prop as it's not an HTML attribute for an anchor tag */
   disabled?: boolean;
   size?: ButtonLinkSize;
   textVariant?: TextVariantName | TextVariantName[];
   variant?: ButtonLinkVariantName;
-}
+};
+
+export interface ButtonLinkProps extends PropsWithAs<'button', NonSemanticButtonLinkProps> {}
 
 const LINK_BUTTON_TEXT_SIZE_MAP: { [key in ButtonLinkSize]: TextVariantName } = {
   large: 'text-ui-16',
@@ -21,58 +25,66 @@ const LINK_BUTTON_TEXT_SIZE_MAP: { [key in ButtonLinkSize]: TextVariantName } = 
   small: 'text-ui-12',
 };
 
-export const ButtonLink = ({
-  as = 'button',
-  children,
-  disabled = false,
-  onClick,
-  size = 'medium',
-  textVariant,
-  tx,
-  variant = 'button-link-blue',
-}: ButtonLinkProps) => {
-  const theme = useTheme();
-  const buttonProps = as === 'button' ? { disabled } : {};
+export const ButtonLink = forwardRefWithAs<NonSemanticButtonLinkProps, 'button'>(
+  (
+    {
+      as = 'button',
+      children,
+      disabled = false,
+      onClick,
+      size = 'medium',
+      textVariant,
+      tx,
+      variant = 'button-link-blue',
+      ...restOfProps
+    }: ButtonLinkProps,
+    ref: Ref<HTMLButtonElement>,
+  ) => {
+    const theme = useTheme();
+    const buttonProps = as === 'button' ? { disabled } : {};
 
-  return (
-    <Box
-      as={as}
-      __baseStyles={{
-        display: 'inline-block',
-        outline: 'none',
-        background: 'transparent',
-        p: 2,
-        border: 0,
-        borderRadius: 4,
-        textDecoration: 'none',
-        fontWeight: 'semibold',
-        cursor: 'pointer',
-
-        '&:hover': {
-          textDecoration: 'underline',
-        },
-
-        '&:disabled, &.disabled': {
+    return (
+      <Box
+        as={as}
+        __baseStyles={{
+          display: 'inline-block',
+          outline: 'none',
+          background: 'transparent',
+          p: 2,
+          border: 0,
+          borderRadius: 4,
           textDecoration: 'none',
-          cursor: 'not-allowed',
-        },
+          fontWeight: 'semibold',
+          cursor: 'pointer',
 
-        '&:focus-visible': {
-          boxShadow: `0 0 0 3px ${theme.colors.focus}`,
-        },
-      }}
-      className={disabled ? 'disabled' : ''}
-      onClick={disabled ? noop : onClick}
-      tx={tx}
-      variant={variant}
-      {...buttonProps}
-    >
-      <Text
-        tx={{ color: 'inherit', fontWeight: 'inherit' }}
-        variant={textVariant ?? LINK_BUTTON_TEXT_SIZE_MAP[size]}
+          '&:hover': {
+            textDecoration: 'underline',
+          },
+
+          '&:disabled, &.disabled': {
+            textDecoration: 'none',
+            cursor: 'not-allowed',
+          },
+
+          '&:focus-visible': {
+            boxShadow: `0 0 0 3px ${theme.colors.focus}`,
+          },
+        }}
+        className={disabled ? 'disabled' : ''}
+        ref={ref}
+        onClick={disabled ? noop : onClick}
+        tx={tx}
+        variant={variant}
+        {...buttonProps}
+        {...restOfProps}
       >
-        {children}
-      </Text>
-    </Box>
-  );
-};
+        <Text
+          tx={{ color: 'inherit', fontWeight: 'inherit' }}
+          variant={textVariant ?? LINK_BUTTON_TEXT_SIZE_MAP[size]}
+        >
+          {children}
+        </Text>
+      </Box>
+    );
+  },
+);

--- a/packages/zephyr/stories/buttons/ButtonLink.stories.tsx
+++ b/packages/zephyr/stories/buttons/ButtonLink.stories.tsx
@@ -42,14 +42,29 @@ export const GreyButtonLink = () => (
   </>
 );
 
-export const BlueButtonLinkAsAsAnchor = () => (
+export const BlueButtonLinkAsAnchor = () => (
   <>
-    <ButtonLink as="a" size="medium" variant="button-link-blue">
+    <ButtonLink
+      as="a"
+      href="https://air.inc/"
+      rel="noopener noreferrer"
+      target="_blank"
+      size="medium"
+      variant="button-link-blue"
+    >
       Blue anchor link
     </ButtonLink>
     <br />
     <br />
-    <ButtonLink as="a" size="medium" disabled variant="button-link-blue">
+    <ButtonLink
+      as="a"
+      href="https://air.inc/"
+      rel="noopener noreferrer"
+      target="_blank"
+      size="medium"
+      disabled
+      variant="button-link-blue"
+    >
       Disabled blue anchor link
     </ButtonLink>
   </>
@@ -57,12 +72,27 @@ export const BlueButtonLinkAsAsAnchor = () => (
 
 export const GreyButtonLinkAsAnchor = () => (
   <>
-    <ButtonLink as="a" size="medium" variant="button-link-grey">
+    <ButtonLink
+      as="a"
+      href="https://air.inc/"
+      rel="noopener noreferrer"
+      target="_blank"
+      size="medium"
+      variant="button-link-grey"
+    >
       Grey anchor link
     </ButtonLink>
     <br />
     <br />
-    <ButtonLink as="a" size="medium" disabled variant="button-link-grey">
+    <ButtonLink
+      as="a"
+      href="https://air.inc/"
+      rel="noopener noreferrer"
+      target="_blank"
+      size="medium"
+      disabled
+      variant="button-link-grey"
+    >
       Disabled grey anchor link
     </ButtonLink>
   </>


### PR DESCRIPTION
ButtonLink
- copy usage of `PropsWithAs` and `forwardRefWithAs` from Button component to pass access to anchor HTML attributes
- tested and updated in Storybook

Button
- remove outdated comment