### PR TITLE
fix: add prop to RadixMenu.Root to prevent looping code

### DIFF
--- a/packages/zephyr/src/RadixMenu/abstractions/RadixDropdownMenu.tsx
+++ b/packages/zephyr/src/RadixMenu/abstractions/RadixDropdownMenu.tsx
@@ -124,7 +124,14 @@ export const RadixDropdownMenu = memo(
     );
 
     return (
-      <Root onOpenChange={handleChange} modal={false} dir="ltr">
+      <Root
+        onOpenChange={handleChange}
+        modal={false}
+        dir="ltr"
+        // `dir` must be provided to in order to prevent Radix from kicking a
+        // looping useDirection hook which clogs the JS thread on browser.
+        // @see https://github.com/radix-ui/primitives/issues/749
+      >
         {/* This overlay is conditional rendered based on if `hasOverlay` prop is passed and it'll apply a transparent div over the entire screen to prevent the user from being able to right click on anything else while the menu is opened. */}
         {hasOverlay && (
           <Box

--- a/packages/zephyr/src/RadixMenu/abstractions/RadixDropdownMenu.tsx
+++ b/packages/zephyr/src/RadixMenu/abstractions/RadixDropdownMenu.tsx
@@ -124,7 +124,7 @@ export const RadixDropdownMenu = memo(
     );
 
     return (
-      <Root onOpenChange={handleChange} modal={false}>
+      <Root onOpenChange={handleChange} modal={false} dir="ltr">
         {/* This overlay is conditional rendered based on if `hasOverlay` prop is passed and it'll apply a transparent div over the entire screen to prevent the user from being able to right click on anything else while the menu is opened. */}
         {hasOverlay && (
           <Box


### PR DESCRIPTION
When `dir` is not provided, `useDirection` kicks a loop to listen to changes to users reading
direction. This is not helpful to us.