### PR TITLE
feat: add divider to radixMenuItemRenderProps

### DIFF
--- a/packages/zephyr/src/RadixMenu/components/RadixMenuItem.tsx
+++ b/packages/zephyr/src/RadixMenu/components/RadixMenuItem.tsx
@@ -15,7 +15,8 @@ import { RadixMenuItemDivider } from './RadixMenuItemDivider';
 export type RadixMenuItemRenderProps =
   | { children: ReactNode }
   | { label: ReactNode; description?: ReactNode }
-  | { title: string };
+  | { title: string }
+  | { divider: boolean };
 
 export type RadixMenuItemProps = Pick<BoxProps, 'tx' | 'id' | 'onClick'> & {
   /**
@@ -234,8 +235,7 @@ export const RadixMenuItem = memo(
       return (
         <Text
           tx={{
-            marginTop: 10,
-            marginBottom: 8,
+            marginY: 8,
             paddingX: size === 'small' ? 6 : 8,
             color: 'pigeon500',
             fontWeight: 'bold',
@@ -250,6 +250,8 @@ export const RadixMenuItem = memo(
         </Text>
       );
     }
+
+    if ('divider' in renderProps) return <RadixMenuItemDivider tx={{ my: 0 }} />;
 
     if (!!subOptions && subOptions.length) {
       return (

--- a/packages/zephyr/src/RadixMenu/components/RadixMenuItem.tsx
+++ b/packages/zephyr/src/RadixMenu/components/RadixMenuItem.tsx
@@ -251,7 +251,7 @@ export const RadixMenuItem = memo(
       );
     }
 
-    if ('divider' in renderProps) return <RadixMenuItemDivider tx={{ my: 0 }} />;
+    if ('divider' in renderProps) return <RadixMenuItemDivider tx={{ marginY: 0 }} />;
 
     if (!!subOptions && subOptions.length) {
       return (

--- a/packages/zephyr/src/RadixMenu/components/RadixMenuItemDivider.tsx
+++ b/packages/zephyr/src/RadixMenu/components/RadixMenuItemDivider.tsx
@@ -3,13 +3,14 @@ import { Separator } from '@radix-ui/react-dropdown-menu';
 
 import { Box } from '../../Box';
 import { MenuVariantName } from '../../theme/variants/menus';
+import { BoxProps } from '../..';
 
-export interface RadixMenuItemDividerProps {
+export interface RadixMenuItemDividerProps extends Pick<BoxProps, 'tx'> {
   isTop?: boolean;
   variant?: MenuVariantName;
 }
 
-export const RadixMenuItemDivider = memo(({ isTop, variant }: RadixMenuItemDividerProps) => {
+export const RadixMenuItemDivider = memo(({ isTop, variant, tx }: RadixMenuItemDividerProps) => {
   return (
     <Box
       as={Separator as FC<Omit<ComponentProps<typeof Separator>, 'as' | 'ref'>>}
@@ -19,6 +20,7 @@ export const RadixMenuItemDivider = memo(({ isTop, variant }: RadixMenuItemDivid
         border: 0,
         mt: isTop ? 0 : 8,
         mb: 8,
+        ...tx,
       }}
     />
   );


### PR DESCRIPTION
### Changes
- Modifies props to allow for a divider
- Aim is to support [something like this](https://www.figma.com/file/aQuCRzJj83m2MU3RCwe8dk/UX-Fast---Q4.21?node-id=131%3A275385)