### PR TITLE
refactor(@air/zephyr): remove baseStyles prop support

### DIFF
--- a/_templates/zephyr/component/component.ejs.t
+++ b/_templates/zephyr/component/component.ejs.t
@@ -8,7 +8,7 @@ import { Box, BoxProps } from './Box';
 export interface <%= name %>Props extends BoxProps {};
 
 export const <%= name %> = forwardRef((props: <%= name %>Props, ref) => {
-  return <Box <% if(locals.asProp){ -%>as="<%= asProp %>"<% } -%> {...props} ref={ref} __baseStyles={{}} />;
+  return <Box <% if(locals.asProp){ -%>as="<%= asProp %>"<% } -%> {...props} ref={ref} />;
 });
 
 <%= name %>.displayName = '<%= name %>';

--- a/packages/zephyr/src/Box.tsx
+++ b/packages/zephyr/src/Box.tsx
@@ -13,12 +13,6 @@ export type BoxStylingProps = {
   tx?: TXProp;
 
   /**
-   * Used to define base styles for the component. These cannot/will not be overridden by `tx` and should only be
-   * leveraged on "primitave" components. Ask if you're uncertain about distinguishing "primitave" versus not.
-   */
-  __baseStyles?: TXProp;
-
-  /**
    * This is used to place a component's potential `variant` usage in the correct object.
    * TODO: Suggest removing this and flattening variants object using long key names
    */
@@ -26,7 +20,6 @@ export type BoxStylingProps = {
 
   /**
    * Used to apply predefined styles.
-   * TODO: Define merging behavior for tx and __baseStyles.
    */
   variant?: string | string[];
 };
@@ -37,8 +30,6 @@ export type BoxProps<TDefaultElement extends As = 'div'> = PropsWithAs<
 >;
 
 const inlineStyles = ({ tx, theme }: any) => css({ ...tx })(theme);
-
-const baseStyles = (props: any) => css(props.__baseStyles)(props.theme);
 
 const variants = ({
   theme,
@@ -57,7 +48,6 @@ export const Box = styled('div')<BoxStylingProps>(
     margin: 0,
     boxSizing: 'border-box',
   },
-  baseStyles,
   variants,
   inlineStyles,
   compose(color, space),

--- a/packages/zephyr/src/Box.tsx
+++ b/packages/zephyr/src/Box.tsx
@@ -20,6 +20,7 @@ export type BoxStylingProps = {
 
   /**
    * Used to apply predefined styles.
+   * TODO: Define merging behavior for tx and __baseStyles.
    */
   variant?: string | string[];
 };
@@ -30,6 +31,8 @@ export type BoxProps<TDefaultElement extends As = 'div'> = PropsWithAs<
 >;
 
 const inlineStyles = ({ tx, theme }: any) => css({ ...tx })(theme);
+
+const baseStyles = (props: any) => css(props.__baseStyles)(props.theme);
 
 const variants = ({
   theme,
@@ -48,6 +51,7 @@ export const Box = styled('div')<BoxStylingProps>(
     margin: 0,
     boxSizing: 'border-box',
   },
+  baseStyles,
   variants,
   inlineStyles,
   compose(color, space),

--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -249,7 +249,6 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
       ref: _ref, // eslint-disable-line @typescript-eslint/no-unused-vars
       children,
       className,
-      tx,
       ...restOfProps
     }: ButtonProps,
     ref: Ref<HTMLButtonElement>,
@@ -280,7 +279,8 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
         type={type}
         variant={variant}
         className={classNames({ 'is-loading': isLoading }, className)}
-        tx={{
+        // @ts-ignore - Allowing it here
+        __baseStyles={{
           appearance: 'none',
           outline: 'none',
           display: 'inline-flex',
@@ -313,7 +313,6 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
           '&.is-loading': {
             cursor: 'progress',
           },
-          ...tx,
         }}
         {...restOfProps}
         ref={ref}

--- a/packages/zephyr/src/Button.tsx
+++ b/packages/zephyr/src/Button.tsx
@@ -249,6 +249,7 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
       ref: _ref, // eslint-disable-line @typescript-eslint/no-unused-vars
       children,
       className,
+      tx,
       ...restOfProps
     }: ButtonProps,
     ref: Ref<HTMLButtonElement>,
@@ -279,7 +280,7 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
         type={type}
         variant={variant}
         className={classNames({ 'is-loading': isLoading }, className)}
-        __baseStyles={{
+        tx={{
           appearance: 'none',
           outline: 'none',
           display: 'inline-flex',
@@ -312,6 +313,7 @@ export const Button = forwardRefWithAs<NonSemanticButtonProps, 'button'>(
           '&.is-loading': {
             cursor: 'progress',
           },
+          ...tx,
         }}
         {...restOfProps}
         ref={ref}

--- a/packages/zephyr/src/ButtonLink.tsx
+++ b/packages/zephyr/src/ButtonLink.tsx
@@ -46,7 +46,7 @@ export const ButtonLink = forwardRefWithAs<NonSemanticButtonLinkProps, 'button'>
     return (
       <Box
         as={as}
-        __baseStyles={{
+        tx={{
           display: 'inline-block',
           outline: 'none',
           background: 'transparent',
@@ -69,11 +69,11 @@ export const ButtonLink = forwardRefWithAs<NonSemanticButtonLinkProps, 'button'>
           '&:focus-visible': {
             boxShadow: `0 0 0 3px ${theme.colors.focus}`,
           },
+          ...tx,
         }}
         className={disabled ? 'disabled' : ''}
         ref={ref}
         onClick={disabled ? noop : onClick}
-        tx={tx}
         variant={variant}
         {...buttonProps}
         {...restOfProps}

--- a/packages/zephyr/src/ButtonLink.tsx
+++ b/packages/zephyr/src/ButtonLink.tsx
@@ -46,7 +46,8 @@ export const ButtonLink = forwardRefWithAs<NonSemanticButtonLinkProps, 'button'>
     return (
       <Box
         as={as}
-        tx={{
+        // @ts-ignore - Allowing it here
+        __baseStyles={{
           display: 'inline-block',
           outline: 'none',
           background: 'transparent',
@@ -69,11 +70,11 @@ export const ButtonLink = forwardRefWithAs<NonSemanticButtonLinkProps, 'button'>
           '&:focus-visible': {
             boxShadow: `0 0 0 3px ${theme.colors.focus}`,
           },
-          ...tx,
         }}
         className={disabled ? 'disabled' : ''}
         ref={ref}
         onClick={disabled ? noop : onClick}
+        tx={tx}
         variant={variant}
         {...buttonProps}
         {...restOfProps}

--- a/packages/zephyr/src/Forms/InputPrimitive.tsx
+++ b/packages/zephyr/src/Forms/InputPrimitive.tsx
@@ -3,10 +3,7 @@ import { Box, BoxProps } from '../Box';
 import { FieldVariantName } from '../theme';
 import { AutoCompleteOptions } from './types';
 
-export type HTMLInputProps = Omit<
-  BoxProps<'input'>,
-  'ref' | 'autoComplete' | 'as' | '__themeKey' | '__baseStyles'
->;
+export type HTMLInputProps = Omit<BoxProps<'input'>, 'ref' | 'autoComplete' | 'as' | '__themeKey'>;
 
 export interface InputPrimitiveProps extends HTMLInputProps {
   /**

--- a/packages/zephyr/src/Forms/LabelPrimitive.tsx
+++ b/packages/zephyr/src/Forms/LabelPrimitive.tsx
@@ -5,10 +5,7 @@ import { TXProp } from '..';
 
 export type LabelSize = 'text-ui-12' | 'text-ui-14';
 
-export type HTMLLabelProps = Omit<
-  BoxProps<'label'>,
-  'as' | 'ref' | '__themeKey' | '__baseStyles' | 'htmlFor'
->;
+export type HTMLLabelProps = Omit<BoxProps<'label'>, 'as' | 'ref' | '__themeKey' | 'htmlFor'>;
 
 export interface LabelPrimitiveProps extends Pick<BoxProps, 'children'>, HTMLLabelProps {
   /**

--- a/packages/zephyr/src/Menus/components/MenuItem.tsx
+++ b/packages/zephyr/src/Menus/components/MenuItem.tsx
@@ -55,6 +55,7 @@ export const MenuItem = ({
   rightAdornment,
   shortcut,
   size = 'small',
+  tx,
   ...restOfProps
 }: MenuItemProps) => {
   const hasDescription = 'description' in restOfProps;
@@ -65,7 +66,7 @@ export const MenuItem = ({
     <>
       {hasDividerTop && <MenuDivider tx={{ mt: 0 }} />}
       <Box
-        __baseStyles={{
+        tx={{
           display: 'flex',
           alignItems: hasDescription ? 'flex-start' : 'center',
           justifyContent: 'space-between',
@@ -87,6 +88,8 @@ export const MenuItem = ({
           '&:focus': { outline: 'none', backgroundColor: 'pigeon050' },
 
           '&:last-child': { mb: 0 },
+
+          ...tx,
         }}
         {...restOfProps}
       >

--- a/packages/zephyr/src/Modals/ModalContent.tsx
+++ b/packages/zephyr/src/Modals/ModalContent.tsx
@@ -19,7 +19,7 @@ interface SharedContentComponentProps
       ComponentProps<typeof DialogContent>,
       'aria-describedby' | 'aria-labelledby' | 'className'
     >,
-    Pick<BoxStylingProps, 'tx' | '__baseStyles' | 'variant'> {
+    Pick<BoxStylingProps, 'tx' | 'variant'> {
   'data-testid'?: string;
   key: string;
 }
@@ -76,9 +76,8 @@ export const ModalContent = ({
     'aria-describedby': descriptionID,
     'aria-labelledby': labelID,
     'data-testid': testID,
-    __baseStyles: baseStyles,
+    tx: { ...baseStyles, ...tx },
     className,
-    tx,
     variant,
     key: testID ?? isAlertModal ? ALERT_MODAL_DIALOG_CONTENT : MODAL_DIALOG_CONTENT,
   };

--- a/packages/zephyr/src/Modals/ModalOverlay.tsx
+++ b/packages/zephyr/src/Modals/ModalOverlay.tsx
@@ -62,7 +62,7 @@ export const ModalOverlay = forwardRef<HTMLElement, ModalOverlayProps>(
         as={MotionAlertDialogOverlay}
         {...motionStyles}
         transition={motionStyles.transition}
-        __baseStyles={baseStyles}
+        tx={baseStyles}
         data-testid={testID}
         key={testID}
         leastDestructiveRef={leastDestructiveRef}
@@ -76,7 +76,7 @@ export const ModalOverlay = forwardRef<HTMLElement, ModalOverlayProps>(
       <Box
         as={MotionDialogOverlay}
         {...motionStyles}
-        __baseStyles={baseStyles}
+        tx={baseStyles}
         data-testid={testID}
         key={testID}
         onDismiss={onDismiss}

--- a/packages/zephyr/src/Text.tsx
+++ b/packages/zephyr/src/Text.tsx
@@ -12,15 +12,14 @@ export interface TextProps extends PropsWithAs<'div', NonSemanticTextProps> {}
 export const Text = forwardRefWithAs<NonSemanticTextProps, 'div'>(
   (
     {
-      variant = 'text-ui-16',
       ref: _ref, // eslint-disable-line @typescript-eslint/no-unused-vars
+      tx,
+      variant = 'text-ui-16',
       ...restOfProps
     }: TextProps,
     ref: Ref<HTMLDivElement>,
   ) => {
-    return (
-      <Box variant={variant} ref={ref} {...restOfProps} __baseStyles={{ color: 'pigeon700' }} />
-    );
+    return <Box variant={variant} ref={ref} {...restOfProps} tx={{ color: 'pigeon700', ...tx }} />;
   },
 );
 

--- a/packages/zephyr/src/Text.tsx
+++ b/packages/zephyr/src/Text.tsx
@@ -12,14 +12,21 @@ export interface TextProps extends PropsWithAs<'div', NonSemanticTextProps> {}
 export const Text = forwardRefWithAs<NonSemanticTextProps, 'div'>(
   (
     {
-      ref: _ref, // eslint-disable-line @typescript-eslint/no-unused-vars
-      tx,
       variant = 'text-ui-16',
+      ref: _ref, // eslint-disable-line @typescript-eslint/no-unused-vars
       ...restOfProps
     }: TextProps,
     ref: Ref<HTMLDivElement>,
   ) => {
-    return <Box variant={variant} ref={ref} {...restOfProps} tx={{ color: 'pigeon700', ...tx }} />;
+    return (
+      <Box
+        variant={variant}
+        ref={ref}
+        {...restOfProps}
+        // @ts-ignore - Allowing it here
+        __baseStyles={{ color: 'pigeon700' }}
+      />
+    );
   },
 );
 


### PR DESCRIPTION
BREAKING CHANGE: All `baseStyles` usage has been removed and is no longer a supported API