### PR TITLE
task/add prop to help with use of radix in our modals

### DIFF
--- a/packages/zephyr/src/Modals/Modal.tsx
+++ b/packages/zephyr/src/Modals/Modal.tsx
@@ -112,6 +112,10 @@ export interface ModalProps
    * an asset or approving a new version of an asset). Can also be used to cue a fork in the road for multi-step forms.
    */
   variant?: ModalVariantName;
+  /**
+   * You should avoid using this. However if you need to use a Radix menu in a modal, this may become necessary since the ModalOverlay used (that is from Radix) "swallows" the onClick that happens with the trigger.
+   */
+  dangerouslyBypassFocusLock?: boolean;
 
   ['data-testid']?: string;
 }
@@ -128,6 +132,7 @@ export const Modal = ({
   modalLabel,
   onDismiss,
   tx,
+  dangerouslyBypassFocusLock = false,
   variant = 'modal-medium',
   withCloseButton = true,
 }: ModalProps) => {
@@ -159,6 +164,7 @@ export const Modal = ({
 
     return (
       <ModalOverlay
+        dangerouslyBypassFocusLock={dangerouslyBypassFocusLock}
         isAlertModal={true}
         onDismiss={onDismiss}
         leastDestructiveRef={withCloseButton ? closeButtonRef : leastDestructiveRef}

--- a/packages/zephyr/src/Modals/ModalOverlay.tsx
+++ b/packages/zephyr/src/Modals/ModalOverlay.tsx
@@ -16,6 +16,10 @@ interface ModalOverlayProps
   isAlertModal: boolean;
   leastDestructiveRef?: RefObject<HTMLElement>;
   shouldReduceMotion: boolean;
+  /**
+   * You should avoid using this. However if you need to use a Radix menu in a modal, this may become necessary since the ModalOverlay used (that is from Radix) "swallows" the onClick that happens with the trigger.
+   */
+  dangerouslyBypassFocusLock?: boolean;
 }
 
 const MotionAlertDialogOverlay = motion.custom(AlertDialogOverlay);

--- a/packages/zephyr/src/Modals/TransactionModal.tsx
+++ b/packages/zephyr/src/Modals/TransactionModal.tsx
@@ -33,6 +33,10 @@ export interface TransactionModalProps
    * by default, but this can be overridden by passing JSX.
    */
   tertiaryCTA?: TransactionModalButton | JSX.Element;
+  /**
+   * You should avoid using this. However if you need to use a Radix menu in a modal, this may become necessary since the ModalOverlay used (that is from Radix) "swallows" the onClick that happens with the trigger.
+   */
+  dangerouslyBypassFocusLock?: boolean;
 
   ['data-testid']?: string;
 }
@@ -47,6 +51,7 @@ export const TransactionModal = ({
   secondaryCTA,
   tertiaryCTA,
   variant,
+  dangerouslyBypassFocusLock,
   ...rest
 }: TransactionModalProps) => {
   const isUsingButtonSchema = useCallback(
@@ -86,6 +91,7 @@ export const TransactionModal = ({
 
   return (
     <Modal
+      dangerouslyBypassFocusLock={dangerouslyBypassFocusLock}
       className={className}
       isAlertModal={false}
       modalDescription={modalDescription}


### PR DESCRIPTION
### Changes 
- Radix dropdowns weren't working in our TransactionModals
  - Radix is using a focusLock and it prevents the trigger from working as intended
- After diving into it with Andy, we realized that the quickest solution is to add this prop 
