### PR TITLE
feat(@air/zephyr): add a textarea primative

### DIFF
--- a/packages/zephyr/src/EditableText/EditableTextTextarea.tsx
+++ b/packages/zephyr/src/EditableText/EditableTextTextarea.tsx
@@ -1,10 +1,7 @@
-import React, { forwardRef, KeyboardEvent } from 'react';
+import { forwardRef, KeyboardEvent } from 'react';
 import { useField, useFormikContext } from 'formik';
-import VisuallyHidden from '@reach/visually-hidden';
-import { useId } from '@reach/auto-id';
-import { TXProp } from '../theme';
-import { Box } from '../Box';
-import { Label } from '../Forms/Label';
+import { TextareaPrimitive } from '../Forms';
+import { TXProp } from '..';
 import { EditableTextFormikValues } from './types';
 
 interface EditableTextTextareaProps {
@@ -26,78 +23,58 @@ export const EditableTextTextarea = forwardRef<HTMLTextAreaElement, EditableText
     forwardedRef,
   ) => {
     const { handleReset, submitForm } = useFormikContext<EditableTextFormikValues>();
-    const autoId = useId();
     const [field] = useField(name);
 
     return (
-      <>
-        <Label for={id} isVisuallyHidden>
-          {label}
-        </Label>
-        <VisuallyHidden>
-          <Box as="p" id={autoId}>
-            Press <kbd>Enter</kbd> to save changes and <kbd>ESC</kbd> to cancel changes.
-          </Box>
-        </VisuallyHidden>
-        <Box
-          aria-describedby={autoId}
-          as="textarea"
-          id={id}
-          maxLength={maxLength}
-          onKeyUp={(event: KeyboardEvent<HTMLTextAreaElement>) => {
-            if (event.key === 'Escape') {
-              event.stopPropagation();
-              handleReset();
-            }
-          }}
-          onKeyPress={async (event: KeyboardEvent<HTMLTextAreaElement>) => {
-            if (event.key === 'Enter' && !event.shiftKey) {
-              event.stopPropagation();
-              event.preventDefault();
-              await submitForm();
-            }
-          }}
-          ref={forwardedRef}
-          required={required}
-          tx={{
-            outline: 'none',
-            position: 'absolute',
-            backgroundColor: 'transparent',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            width: '100%',
-            maxWidth: '100%',
-            height: '100%',
-            maxHeight: '100%',
-            p: 0,
-            border: 'none',
-            color: 'inherit',
-            fontFamily: 'inherit',
-            fontFeatureSettings: 'inherit',
-            fontSize: 'inherit',
-            fontWeight: 'inherit',
-            letterSpacing: 'inherit',
-            lineHeight: 'inherit',
-            whiteSpace: 'pre-wrap',
-            resize: 'none',
-            overflow: 'hidden',
-            /**
-             * @todo I will deal with this at a later date, already spent 1+ hours on this.
-             */
-            ...tx,
-          }}
-          {...field}
-          onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
-            field.onChange(event);
-            onValueChange?.(event.target?.value);
-          }}
-          onBlur={() => {
-            submitForm();
-          }}
-        />
-      </>
+      <TextareaPrimitive
+        aria-label={label}
+        id={id}
+        maxLength={maxLength}
+        onKeyPress={async (event: KeyboardEvent<HTMLTextAreaElement>) => {
+          if (event.key === 'Enter' && !event.shiftKey) {
+            event.stopPropagation();
+            event.preventDefault();
+            await submitForm();
+          }
+        }}
+        onKeyUp={(event: KeyboardEvent<HTMLTextAreaElement>) => {
+          if (event.key === 'Escape') {
+            event.stopPropagation();
+            handleReset();
+          }
+        }}
+        ref={forwardedRef}
+        required={required}
+        tx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          width: '100%',
+          maxWidth: '100%',
+          height: '100%',
+          maxHeight: '100%',
+          overflow: 'hidden',
+          color: 'inherit',
+          fontFamily: 'inherit',
+          fontFeatureSettings: 'inherit',
+          fontSize: 'inherit',
+          fontWeight: 'inherit',
+          letterSpacing: 'inherit',
+          lineHeight: 'inherit',
+          ...tx,
+        }}
+        variant={'unstyled'}
+        {...field}
+        onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+          field.onChange(event);
+          onValueChange?.(event.target?.value);
+        }}
+        onBlur={() => {
+          submitForm();
+        }}
+      />
     );
   },
 );

--- a/packages/zephyr/src/EditableText/index.tsx
+++ b/packages/zephyr/src/EditableText/index.tsx
@@ -245,11 +245,11 @@ export const EditableText = ({
                 {isEditingState && (
                   <Box as={Form} tx={{ position: 'unset' }}>
                     <EditableTextTextarea
-                      onValueChange={onValueChange}
                       id={autoId}
                       label={label}
                       maxLength={maxLength}
                       name="editable-text-value"
+                      onValueChange={onValueChange}
                       ref={textareaRef}
                       required
                       tx={textareaStyles}

--- a/packages/zephyr/src/Forms/TextareaPrimitive.tsx
+++ b/packages/zephyr/src/Forms/TextareaPrimitive.tsx
@@ -1,0 +1,61 @@
+import { forwardRef, useMemo } from 'react';
+import { Box, BoxProps } from '../Box';
+import { commonFieldStyles, TXProp } from '../theme';
+
+const coreTextareaStyles: TXProp = {
+  resize: 'none',
+  whiteSpace: 'pre-wrap',
+  fontSize: 16,
+};
+
+export type TextareaSizeOption = 'small' | 'large';
+export const textareaSizeStyles: { [key in TextareaSizeOption]: TXProp } = {
+  // these lineHeights allow a single-row Textarea to visually match our corresponding Inputs
+  small: { lineHeight: '18px' },
+  large: { lineHeight: '26px' },
+};
+
+export type TextareaVariantOption = 'default' | 'unstyled';
+export const textareaVariantStyles: { [key in TextareaVariantOption]: TXProp } = {
+  default: {
+    ...coreTextareaStyles,
+    ...commonFieldStyles,
+  },
+  unstyled: {
+    ...coreTextareaStyles,
+    outline: 'none',
+    backgroundColor: 'transparent',
+    p: 0,
+    border: 'none',
+  },
+};
+
+export interface TextareaPrimitiveProps
+  extends Omit<BoxProps<'textarea'>, 'ref' | 'autoComplete' | 'as' | '__themeKey'> {
+  'data-testid'?: string;
+  size?: TextareaSizeOption;
+  tx?: TXProp;
+  variant?: TextareaVariantOption;
+}
+/*
+ * This is designed to be used by itself, or as part of EditableText or Formik.
+ * If using with Formik, pass 'field' from useField hook.
+ */
+export const TextareaPrimitive = forwardRef<HTMLTextAreaElement, TextareaPrimitiveProps>(
+  (
+    { 'data-testid': testId, size, tx, variant = 'default', ...rest }: TextareaPrimitiveProps,
+    forwardedRef,
+  ) => {
+    const combinedTx = useMemo(() => {
+      return {
+        ...textareaVariantStyles[variant],
+        ...(size ? textareaSizeStyles[size] : undefined),
+        ...tx,
+      };
+    }, [size, tx, variant]);
+
+    return <Box as="textarea" data-testid={testId} ref={forwardedRef} tx={combinedTx} {...rest} />;
+  },
+);
+
+TextareaPrimitive.displayName = 'TextareaPrimitive';

--- a/packages/zephyr/src/Forms/index.ts
+++ b/packages/zephyr/src/Forms/index.ts
@@ -5,5 +5,6 @@ export * from './InputPrimitive';
 export * from './Label';
 export * from './LabelPrimitive';
 export * from './SingleSelect';
+export * from './TextareaPrimitive';
 export * from './Toggle/Toggle';
 export * from './Toggle/FormikToggle';

--- a/packages/zephyr/stories/forms/TextareaPrimitive.stories.tsx
+++ b/packages/zephyr/stories/forms/TextareaPrimitive.stories.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react';
+import { Box } from '../../src/Box';
+import {
+  TextareaPrimitive,
+  TextareaPrimitiveProps,
+  TextareaSizeOption,
+  textareaSizeStyles,
+} from '../../src/Forms/TextareaPrimitive';
+import { LabelPrimitive } from '../../src/Forms/LabelPrimitive';
+
+export default {
+  title: 'Zephyr/Forms/TextareaPrimitive',
+  component: TextareaPrimitive,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'This component is a core `textarea`.<br><br> Use `rows` prop (default `2`) to control height unless you specifically need finer control.',
+      },
+      source: {
+        code: `/**
+    * Unfortunately, we can't render source code correctly on the initial story.
+    * Please see https://github.com/storybookjs/storybook/issues/12022
+    */`,
+      },
+    },
+  },
+} as Meta;
+
+const sizes = Object.keys(textareaSizeStyles) as TextareaSizeOption[];
+
+const Template: Story<TextareaPrimitiveProps> = (args) => {
+  return <TextareaPrimitive {...args} tx={{ width: 200, mr: 12 }} />;
+};
+
+export const Default = Template.bind({});
+
+export const Sizes: Story<TextareaPrimitiveProps> = () => {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box tx={{ display: 'flex', flexDirection: 'column', width: 200 }}>
+      {sizes.map((size) => {
+        const isLarge = size === 'large';
+        const label = `Single Row ${isLarge ? '(Large)' : '(Small)'}`;
+        const fieldId = `default_size_${isLarge ? 'large' : 'small'}`;
+
+        return (
+          <Box key={size}>
+            <LabelPrimitive for={fieldId} showAsterisk tx={{ mb: 4, Asterisk: { color: 'red' } }}>
+              {label}
+            </LabelPrimitive>
+            <TextareaPrimitive
+              id={fieldId}
+              onChange={(e) => setValue(e.target.value)}
+              required
+              rows={1}
+              tx={{ mr: 24, mb: 24 }}
+              value={value}
+              size={size}
+            />
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
+Sizes.parameters = {
+  docs: {
+    description: {
+      story: 'Sizes shown with `rows=1` and a `LabelPrimitive`.',
+    },
+  },
+};
+
+export const Disabled: Story<TextareaPrimitiveProps> = (args) => {
+  return (
+    <Box tx={{ display: 'flex', flexDirection: 'column', width: 200 }}>
+      <TextareaPrimitive disabled id={'textarea-disabled'} required {...args} />
+    </Box>
+  );
+};
+
+export const Placeholder: Story<TextareaPrimitiveProps> = (args) => {
+  return (
+    <Box tx={{ display: 'flex', flexDirection: 'column', width: 200 }}>
+      <TextareaPrimitive
+        placeholder={'this is a placeholder'}
+        id={'textarea-placeholder'}
+        required
+        {...args}
+      />
+    </Box>
+  );
+};
+
+export const Unstyled: Story<TextareaPrimitiveProps> = (args) => {
+  return (
+    <Box tx={{ display: 'flex', flexDirection: 'column', width: 200 }}>
+      <TextareaPrimitive variant="unstyled" id={'textarea-unstyled'} required {...args} />
+    </Box>
+  );
+};


### PR DESCRIPTION
adds a `TextareaPrimative` which is now the base textarea consumed by `EditableText`, and can also be used on its own.